### PR TITLE
set header to sticky

### DIFF
--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -77,7 +77,7 @@ export const AppHeader: React.FC = () => {
   const isOnCustomers = location.pathname === '/customers';
 
   return (
-    <header className="sticky top-0 z-50 bg-white border-b border-gray-200 shadow-sm">
+    <header className="sticky top-0 z-50 bg-white border-b border-gray-200 shadow-sm backdrop-blur-sm">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex justify-between items-center h-16">
           {/* Left Section - Mobile Menu + Logo */}


### PR DESCRIPTION
This pull request makes several UI improvements to the `AppHeader` component to enhance layout consistency and navigation visibility, especially on large screens. The main changes focus on making the header sticky, adjusting spacing in the navigation, and ensuring navigation labels are visible on more screen sizes.

**Header layout improvements:**

* Made the header sticky to the top of the page by adding `sticky top-0 z-50` to the header's class list, ensuring it remains visible during scrolling.

**Navigation and spacing updates:**

* Increased spacing between navigation items for better readability by changing `space-x-1` to `space-x-3` in the navigation bar.

**Navigation label visibility adjustments:**

* Changed navigation label visibility from `xl` to `lg` breakpoint, making labels like "Home", "New Order", "History", "Customers", "Services", and "Stores" visible on large screens instead of only extra-large screens. [[1]](diffhunk://#diff-e9b4ff8d9befa0a2797931b6ea2c8d4e4308677c3d4e81bf5d9accb14eab808aL151-R151) [[2]](diffhunk://#diff-e9b4ff8d9befa0a2797931b6ea2c8d4e4308677c3d4e81bf5d9accb14eab808aL165-R165) [[3]](diffhunk://#diff-e9b4ff8d9befa0a2797931b6ea2c8d4e4308677c3d4e81bf5d9accb14eab808aL179-R179) [[4]](diffhunk://#diff-e9b4ff8d9befa0a2797931b6ea2c8d4e4308677c3d4e81bf5d9accb14eab808aL193-R193) [[5]](diffhunk://#diff-e9b4ff8d9befa0a2797931b6ea2c8d4e4308677c3d4e81bf5d9accb14eab808aL210-R210) [[6]](diffhunk://#diff-e9b4ff8d9befa0a2797931b6ea2c8d4e4308677c3d4e81bf5d9accb14eab808aL224-R224)