### PR TITLE
fix sender payload request

### DIFF
--- a/api/whatsapp-send.js
+++ b/api/whatsapp-send.js
@@ -29,7 +29,7 @@ export default async function handler(req, res) {
       timestamp: new Date().toISOString()
     });
 
-    const { to, message } = req.body;
+    const { to, message, from } = req.body;
     
     if (!to || !message) {
       return res.status(400).json({
@@ -59,13 +59,18 @@ export default async function handler(req, res) {
     console.log('🔗 Forwarding to:', whatsappApiEndpoint);
 
     // Forward the request to the actual WhatsApp API
+    const requestBody = { to, message };
+    if (from) {
+      requestBody.from = from;
+    }
+    
     const response = await fetch(whatsappApiEndpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Basic ${credentials}`,
       },
-      body: JSON.stringify({ to, message }),
+      body: JSON.stringify(requestBody),
     });
 
     const responseText = await response.text();

--- a/whatsapp-proxy.js
+++ b/whatsapp-proxy.js
@@ -42,7 +42,7 @@ app.post('/api/whatsapp/send-message', async (req, res) => {
       timestamp: new Date().toISOString()
     });
 
-    const { to, message } = req.body;
+    const { to, message, from } = req.body;
     
     if (!to || !message) {
       return res.status(400).json({
@@ -57,13 +57,18 @@ app.post('/api/whatsapp/send-message', async (req, res) => {
     
     console.log('🔗 Forwarding to:', whatsappApiEndpoint);
     
+    const requestBody = { to, message };
+    if (from) {
+      requestBody.from = from;
+    }
+    
     const response = await fetch(whatsappApiEndpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Basic ${credentials}`,
       },
-      body: JSON.stringify({ to, message }),
+      body: JSON.stringify(requestBody),
     });
 
     const responseText = await response.text();


### PR DESCRIPTION
This pull request updates both the `api/whatsapp-send.js` and `whatsapp-proxy.js` endpoints to support an optional `from` field in WhatsApp message requests. The code now forwards the `from` field to the WhatsApp API if it is provided in the request body, ensuring better flexibility for specifying the sender.

**Support for optional `from` field in WhatsApp message requests:**

* Both `api/whatsapp-send.js` and `whatsapp-proxy.js` now extract `from` from the incoming request body, along with `to` and `message`. [[1]](diffhunk://#diff-3b8045f211d171b3bd2a491859d34f178086cd7b0eb860bce698788761541c41L32-R32) [[2]](diffhunk://#diff-fb24bf11ed753acfc4451a528301fd1dcad662bd3f0f512f1ffece4671898463L45-R45)
* When forwarding the request to the WhatsApp API, the code constructs a `requestBody` object that includes `from` only if it is present, otherwise only `to` and `message` are sent. [[1]](diffhunk://#diff-3b8045f211d171b3bd2a491859d34f178086cd7b0eb860bce698788761541c41R62-R73) [[2]](diffhunk://#diff-fb24bf11ed753acfc4451a528301fd1dcad662bd3f0f512f1ffece4671898463R60-R71)