### PR TITLE
POS activation onboarding + Google Sign-In

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,9 @@ VITE_WHATSAPP_API_URL=http://localhost:8080
 VITE_WHATSAPP_API_USERNAME=admin
 VITE_WHATSAPP_API_PASSWORD=your_secure_password
 VITE_WHATSAPP_API_TIMEOUT=10000
+
+# Google Sign-In (optional)
+# OAuth 2.0 Web Client ID from Google Cloud Console > Credentials.
+# Add your app origins (e.g. http://localhost:8080 and your production domain)
+# to "Authorized JavaScript origins". Leave blank to hide the Google button.
+VITE_GOOGLE_CLIENT_ID=your_google_oauth_client_id.apps.googleusercontent.com

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ public/favicon-generator.html
 
 
 research/
+.env*

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "@radix-ui/react-toggle": "^1.1.0",
         "@radix-ui/react-toggle-group": "^1.1.0",
         "@radix-ui/react-tooltip": "^1.1.4",
+        "@react-oauth/google": "^0.13.5",
         "@supabase/supabase-js": "^2.52.1",
         "@tanstack/react-query": "^5.83.0",
         "@tanstack/react-query-devtools": "^5.83.0",
@@ -2620,6 +2621,16 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
       "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
       "license": "MIT"
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.13.5.tgz",
+      "integrity": "sha512-xQWri2s/3nNekZJ4uuov2aAfQYu83bN3864KcFqw2pK1nNbFurQIjPFDXhWaKH3IjYJ2r/9yyIIpsn5lMqrheQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
     },
     "node_modules/@remix-run/router": {
       "version": "1.20.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@radix-ui/react-toggle": "^1.1.0",
     "@radix-ui/react-toggle-group": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.4",
+    "@react-oauth/google": "^0.13.5",
     "@supabase/supabase-js": "^2.52.1",
     "@tanstack/react-query": "^5.83.0",
     "@tanstack/react-query-devtools": "^5.83.0",

--- a/src/components/auth/GoogleLoginButton.tsx
+++ b/src/components/auth/GoogleLoginButton.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { GoogleOAuthProvider, GoogleLogin } from '@react-oauth/google';
+import { useAuth } from '@/contexts/AuthContext';
+import { useToast } from '@/hooks/use-toast';
+
+const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined;
+
+/**
+ * Google Sign-In button. Renders a divider + Google button.
+ * No-op (renders nothing) when VITE_GOOGLE_CLIENT_ID is not configured, so the
+ * app works unchanged in environments without Google OAuth set up.
+ */
+export const GoogleLoginButton: React.FC = () => {
+  const { signInWithGoogle } = useAuth();
+  const { toast } = useToast();
+
+  if (!GOOGLE_CLIENT_ID) {
+    return null;
+  }
+
+  return (
+    <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
+      <div className="mt-6">
+        <div className="relative">
+          <div className="absolute inset-0 flex items-center">
+            <span className="w-full border-t border-gray-200" />
+          </div>
+          <div className="relative flex justify-center text-xs uppercase">
+            <span className="bg-white px-2 text-gray-400">atau</span>
+          </div>
+        </div>
+
+        <div className="mt-4 flex justify-center">
+          <GoogleLogin
+            onSuccess={async (credentialResponse) => {
+              if (!credentialResponse.credential) {
+                toast({
+                  title: 'Error',
+                  description: 'Tidak ada kredensial dari Google',
+                  variant: 'destructive',
+                });
+                return;
+              }
+              try {
+                await signInWithGoogle(credentialResponse.credential);
+              } catch {
+                // Error toast handled in AuthContext
+              }
+            }}
+            onError={() => {
+              toast({
+                title: 'Error',
+                description: 'Gagal masuk dengan Google',
+                variant: 'destructive',
+              });
+            }}
+            text="continue_with"
+            shape="rectangular"
+            width="320"
+          />
+        </div>
+      </div>
+    </GoogleOAuthProvider>
+  );
+};

--- a/src/components/pos/EnhancedLaundryPOS.tsx
+++ b/src/components/pos/EnhancedLaundryPOS.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { useCustomers } from '@/hooks/useCustomers';
 import { useCreateOrderWithNotifications as useCreateOrder, UnitItem } from '@/hooks/useOrdersWithNotifications';
 import { toast } from 'sonner';
-import { useServices } from '@/hooks/useServices';
+import { useServices, useSeedDefaultServices } from '@/hooks/useServices';
 import { EnhancedOrderItem } from './EnhancedServiceSelector';
 import { DynamicOrderItemData } from './DynamicOrderItem';
 import { EnhancedServiceSelectionPopup } from './EnhancedServiceSelectionPopup';
@@ -60,6 +60,7 @@ export const EnhancedLaundryPOS = () => {
 
   // Load services from our service management system
   const { data: servicesData, isLoading: servicesLoading, error: servicesError } = useServices();
+  const seedDefaultServices = useSeedDefaultServices();
 
   // Helper function to calculate finish date based on service duration
   const calculateFinishDate = (service: any, startDate: Date = dropOffDate) => {
@@ -686,19 +687,29 @@ export const EnhancedLaundryPOS = () => {
       {servicesData && servicesData.length === 0 && (
         <Card className="border-orange-200 bg-orange-50">
           <CardContent className="p-4">
-            <div className="flex items-center justify-between">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
               <div>
                 <h3 className="font-medium text-orange-800">Belum ada layanan yang dikonfigurasi</h3>
                 <p className="text-sm text-orange-600">
-                  Anda perlu membuat layanan terlebih dahulu sebelum menerima pesanan.
+                  Tambahkan layanan untuk mulai menerima pesanan. Muat contoh layanan untuk langsung mulai.
                 </p>
               </div>
-              <Button 
-                onClick={() => navigate('/services')}
-                className="bg-orange-600 hover:bg-orange-700"
-              >
-                Kelola Layanan
-              </Button>
+              <div className="flex flex-shrink-0 gap-2">
+                <Button
+                  onClick={() => seedDefaultServices.mutate()}
+                  disabled={seedDefaultServices.isPending}
+                  className="bg-orange-600 hover:bg-orange-700"
+                >
+                  {seedDefaultServices.isPending ? 'Memuat...' : 'Muat Contoh Layanan'}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={() => navigate('/services')}
+                  className="border-orange-300 text-orange-700 hover:bg-orange-100"
+                >
+                  Kelola Layanan
+                </Button>
+              </div>
             </div>
           </CardContent>
         </Card>

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -6,6 +6,7 @@ interface AuthContextType {
   user: User | null;
   loading: boolean;
   signIn: (email: string, password: string) => Promise<void>;
+  signInWithGoogle: (credential: string) => Promise<void>;
   signOut: () => Promise<void>;
   signUp: (email: string, password: string, fullName?: string, phone?: string, role?: 'staff' | 'laundry_owner', storeData?: { name: string; address?: string; phone?: string; }) => Promise<void>;
   changePassword: (currentPassword: string, newPassword: string) => Promise<void>;
@@ -44,6 +45,29 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       toast({
         title: "Success",
         description: "Signed in successfully!",
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'An error occurred';
+      toast({
+        title: "Error",
+        description: errorMessage,
+        variant: "destructive",
+      });
+      throw error;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const signInWithGoogle = async (credential: string) => {
+    try {
+      setLoading(true);
+      const user = await authService.signInWithGoogle(credential);
+      setUser(user);
+
+      toast({
+        title: "Success",
+        description: "Signed in with Google!",
       });
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'An error occurred';
@@ -131,6 +155,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     user,
     loading,
     signIn,
+    signInWithGoogle,
     signOut,
     signUp,
     changePassword,

--- a/src/hooks/useActivation.ts
+++ b/src/hooks/useActivation.ts
@@ -1,0 +1,78 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useStore } from '@/contexts/StoreContext';
+
+export interface ActivationStatus {
+  hasServices: boolean;
+  hasOrder: boolean;
+  hasCustomer: boolean;
+  /** Number of completed onboarding steps (store is always step 1). */
+  completedSteps: number;
+  totalSteps: number;
+  /** True once the owner has created their first order. */
+  isActivated: boolean;
+}
+
+// Lightweight existence checks used to drive the "Getting Started" checklist on
+// the home screen. Uses head/count queries (no rows fetched) so it's cheap.
+const existsForStore = async (
+  table: 'services' | 'orders' | 'customers',
+  storeId: string
+): Promise<boolean> => {
+  let query = supabase
+    .from(table)
+    .select('id', { count: 'exact', head: true })
+    .eq('store_id', storeId);
+
+  // Only count active services (matches how the POS reads the catalog).
+  if (table === 'services') {
+    query = query.eq('is_active', true);
+  }
+
+  const { count, error } = await query;
+  if (error) {
+    console.error(`Error checking existence in ${table}:`, error);
+    return false;
+  }
+  return (count ?? 0) > 0;
+};
+
+/**
+ * Returns the store's onboarding/activation status for the current store.
+ * Drives the home-screen getting-started checklist; refetched when orders,
+ * services or customers change via the shared query key invalidations.
+ */
+export const useActivation = () => {
+  const { currentStore } = useStore();
+  const storeId = currentStore?.store_id;
+
+  return useQuery({
+    queryKey: ['activation', storeId],
+    enabled: !!storeId,
+    staleTime: 60 * 1000,
+    queryFn: async (): Promise<ActivationStatus> => {
+      if (!storeId) {
+        throw new Error('No store selected');
+      }
+
+      const [hasServices, hasOrder, hasCustomer] = await Promise.all([
+        existsForStore('services', storeId),
+        existsForStore('orders', storeId),
+        existsForStore('customers', storeId),
+      ]);
+
+      // Step 1 (store created) is always complete on this screen.
+      const completedSteps =
+        1 + [hasServices, hasOrder, hasCustomer].filter(Boolean).length;
+
+      return {
+        hasServices,
+        hasOrder,
+        hasCustomer,
+        completedSteps,
+        totalSteps: 4,
+        isActivated: hasOrder,
+      };
+    },
+  });
+};

--- a/src/hooks/useServices.ts
+++ b/src/hooks/useServices.ts
@@ -37,6 +37,45 @@ export interface ServiceFormData {
   is_active?: boolean;
 }
 
+// Default starter services seeded for a new store so the POS is usable
+// immediately. Keep in sync with the create_store() SQL function
+// (supabase/migrations/20260621000000_seed_default_services_on_store_create.sql).
+export const DEFAULT_SERVICES: ServiceFormData[] = [
+  {
+    name: 'Cuci Setrika Regular',
+    description: 'Cuci - Pengeringan - Setrika - Packing',
+    category: 'wash',
+    unit_price: 18000,
+    kilo_price: 6000,
+    supports_unit: true,
+    supports_kilo: true,
+    duration_value: 2,
+    duration_unit: 'days',
+  },
+  {
+    name: 'Express Wash',
+    description: 'Pencucian cepat dalam 24 jam',
+    category: 'wash',
+    unit_price: 25000,
+    kilo_price: 8000,
+    supports_unit: true,
+    supports_kilo: true,
+    duration_value: 1,
+    duration_unit: 'days',
+  },
+  {
+    name: 'Setrika Saja',
+    description: 'Layanan setrika dan pressing saja',
+    category: 'ironing',
+    unit_price: 5000,
+    kilo_price: 3000,
+    supports_unit: true,
+    supports_kilo: true,
+    duration_value: 4,
+    duration_unit: 'hours',
+  },
+];
+
 // Hook to fetch services for the current store
 export const useServices = (category?: string) => {
   const { currentStore } = useStore();
@@ -130,6 +169,52 @@ export const useCreateService = () => {
         title: "Error",
         description: "Failed to create service",
         variant: "destructive",
+      });
+    },
+  });
+};
+
+// Hook to seed the default starter services for the current store in one batch.
+// Used by empty-state CTAs (POS notice, Service Management) so a new owner can
+// get a working catalog with a single tap.
+export const useSeedDefaultServices = () => {
+  const queryClient = useQueryClient();
+  const { currentStore } = useStore();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (): Promise<void> => {
+      if (!currentStore?.store_id) {
+        throw new Error('No store selected');
+      }
+
+      const { error } = await supabase
+        .from('services')
+        .insert(
+          DEFAULT_SERVICES.map((service) => ({
+            ...service,
+            store_id: currentStore.store_id,
+            is_active: true,
+          }))
+        );
+
+      if (error) {
+        console.error('Error seeding default services:', error);
+        throw error;
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['services'] });
+      toast({
+        title: 'Berhasil',
+        description: 'Contoh layanan berhasil dibuat',
+      });
+    },
+    onError: () => {
+      toast({
+        title: 'Error',
+        description: 'Gagal memuat contoh layanan',
+        variant: 'destructive',
       });
     },
   });

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,14 +2,16 @@ import React from 'react';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useDashboard } from '@/hooks/useDashboard';
 import { useTodayExpenses } from '@/hooks/useRevenue';
+import { useActivation } from '@/hooks/useActivation';
 import { useNavigate } from 'react-router-dom';
 import { useStore } from '@/contexts/StoreContext';
 import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { Coachmark, useCoachmark } from '@/components/ui/coachmark';
-import { 
-  Building2, 
-  Plus, 
-  Users, 
+import {
+  Building2,
+  Plus,
+  Users,
   Wrench,
   CreditCard,
   QrCode,
@@ -20,7 +22,10 @@ import {
   Home as HomeIcon,
   ShoppingCart,
   BarChart3,
-  Settings
+  Settings,
+  CheckCircle2,
+  Circle,
+  ArrowRight
 } from 'lucide-react';
 
 export const HomePage: React.FC = () => {
@@ -28,6 +33,7 @@ export const HomePage: React.FC = () => {
   const { currentStore, isOwner } = useStore();
   const { metrics, loading } = useDashboard();
   const { data: todayExpensesData, isLoading: loadingExpenses } = useTodayExpenses();
+  const { data: activation } = useActivation();
   const navigate = useNavigate();
   const { shouldShowCoachmark, hideCoachmark } = useCoachmark();
 
@@ -67,6 +73,39 @@ export const HomePage: React.FC = () => {
   const todayExpenses = todayExpensesData || 0;
   const todayIncomeChange = metrics?.todayRevenue?.changeFromYesterday || 0;
   const isLoadingData = loading || loadingExpenses;
+
+  // Show the getting-started checklist until the store creates its first order.
+  const showOnboarding = !!activation && !activation.isActivated;
+  const onboardingSteps = [
+    {
+      id: 'store',
+      title: 'Buat toko',
+      description: 'Toko Anda sudah siap digunakan.',
+      done: true,
+      onClick: () => navigate('/stores'),
+    },
+    {
+      id: 'services',
+      title: 'Siapkan layanan',
+      description: 'Tambahkan layanan laundry beserta harganya.',
+      done: !!activation?.hasServices,
+      onClick: () => navigate('/services'),
+    },
+    {
+      id: 'order',
+      title: 'Buat pesanan pertama',
+      description: 'Catat pesanan laundry pertama Anda.',
+      done: !!activation?.hasOrder,
+      onClick: () => navigate('/pos'),
+    },
+    {
+      id: 'customer',
+      title: 'Tambah pelanggan',
+      description: 'Simpan data pelanggan untuk pemesanan berikutnya.',
+      done: !!activation?.hasCustomer,
+      onClick: () => navigate('/customers'),
+    },
+  ];
 
   const quickActions = [
     {
@@ -192,37 +231,98 @@ export const HomePage: React.FC = () => {
           </CardContent>
         </Card>
 
-        {/* Revenue Cards */}
-        <div className="grid grid-cols-2 gap-3">
-          <Card className="shadow-md border-0">
-            <CardContent className="p-4">
-              <div className="flex items-start justify-between mb-2">
-                <p className="text-xs text-gray-600">Pendapatan Hari Ini</p>
-                <TrendingUp className="h-4 w-4 text-green-500" />
+        {/* Getting-started checklist (new stores) OR revenue cards (activated stores) */}
+        {showOnboarding ? (
+          <Card className="shadow-lg border-0">
+            <CardContent className="p-5">
+              <div className="mb-1 flex items-center justify-between">
+                <h3 className="text-base font-bold text-gray-900">Mulai Cepat</h3>
+                <span className="text-xs font-medium text-rose-500">
+                  {activation!.completedSteps}/{activation!.totalSteps} selesai
+                </span>
               </div>
-              <p className="text-lg font-bold text-gray-900">
-                {isLoadingData ? '...' : formatCurrency(todayIncome)}
+              <p className="mb-3 text-sm text-gray-500">
+                Selesaikan langkah berikut untuk mulai menerima pesanan.
               </p>
-              {todayIncomeChange !== 0 && (
-                <p className={`text-xs mt-1 ${todayIncomeChange >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                  {todayIncomeChange >= 0 ? '↑' : '↓'} {Math.abs(todayIncomeChange)}% dari kemarin
-                </p>
-              )}
-            </CardContent>
-          </Card>
 
-          <Card className="shadow-md border-0">
-            <CardContent className="p-4">
-              <div className="flex items-start justify-between mb-2">
-                <p className="text-xs text-gray-600">Pengeluaran Hari Ini</p>
-                <TrendingDown className="h-4 w-4 text-orange-500" />
+              {/* Progress bar */}
+              <div className="mb-4 h-2 w-full overflow-hidden rounded-full bg-gray-100">
+                <div
+                  className="h-full rounded-full bg-rose-500 transition-all"
+                  style={{ width: `${(activation!.completedSteps / activation!.totalSteps) * 100}%` }}
+                />
               </div>
-              <p className="text-lg font-bold text-gray-900">
-                {isLoadingData ? '...' : formatCurrency(todayExpenses)}
-              </p>
+
+              <div className="space-y-1">
+                {onboardingSteps.map((step) => (
+                  <button
+                    key={step.id}
+                    onClick={step.onClick}
+                    className="flex w-full items-center gap-3 rounded-xl p-2 text-left transition-colors hover:bg-gray-50 active:scale-[0.99]"
+                  >
+                    {step.done ? (
+                      <CheckCircle2 className="h-6 w-6 flex-shrink-0 text-green-500" />
+                    ) : (
+                      <Circle className="h-6 w-6 flex-shrink-0 text-gray-300" />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <p
+                        className={`text-sm font-medium ${
+                          step.done ? 'text-gray-400 line-through' : 'text-gray-900'
+                        }`}
+                      >
+                        {step.title}
+                      </p>
+                      {!step.done && (
+                        <p className="text-xs text-gray-500">{step.description}</p>
+                      )}
+                    </div>
+                    {!step.done && <ArrowRight className="h-4 w-4 flex-shrink-0 text-gray-300" />}
+                  </button>
+                ))}
+              </div>
+
+              <Button
+                onClick={() => navigate('/pos')}
+                className="mt-4 w-full bg-rose-500 hover:bg-rose-600"
+              >
+                <Plus className="mr-1 h-4 w-4" />
+                Buat Pesanan Pertama
+              </Button>
             </CardContent>
           </Card>
-        </div>
+        ) : (
+          <div className="grid grid-cols-2 gap-3">
+            <Card className="shadow-md border-0">
+              <CardContent className="p-4">
+                <div className="flex items-start justify-between mb-2">
+                  <p className="text-xs text-gray-600">Pendapatan Hari Ini</p>
+                  <TrendingUp className="h-4 w-4 text-green-500" />
+                </div>
+                <p className="text-lg font-bold text-gray-900">
+                  {isLoadingData ? '...' : formatCurrency(todayIncome)}
+                </p>
+                {todayIncomeChange !== 0 && (
+                  <p className={`text-xs mt-1 ${todayIncomeChange >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                    {todayIncomeChange >= 0 ? '↑' : '↓'} {Math.abs(todayIncomeChange)}% dari kemarin
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card className="shadow-md border-0">
+              <CardContent className="p-4">
+                <div className="flex items-start justify-between mb-2">
+                  <p className="text-xs text-gray-600">Pengeluaran Hari Ini</p>
+                  <TrendingDown className="h-4 w-4 text-orange-500" />
+                </div>
+                <p className="text-lg font-bold text-gray-900">
+                  {isLoadingData ? '...' : formatCurrency(todayExpenses)}
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        )}
 
         {/* Quick Actions Grid */}
         <div className="grid grid-cols-3 gap-3 mt-6">

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -11,6 +11,7 @@ import { Loader2, Eye, EyeOff, ChevronDown } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { PageLoading } from '@/components/ui/loading-spinner';
+import { GoogleLoginButton } from '@/components/auth/GoogleLoginButton';
 
 interface LoginForm {
   email: string;
@@ -309,6 +310,9 @@ export const Login: React.FC = () => {
               </form>
             </TabsContent>
           </Tabs>
+
+          {/* Google sign-in (shared by both tabs; hidden when not configured) */}
+          <GoogleLoginButton />
         </CardContent>
         <CardFooter className="text-center">
           <p className="text-sm text-gray-600">

--- a/src/pages/ServiceManagement.tsx
+++ b/src/pages/ServiceManagement.tsx
@@ -11,7 +11,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import { usePageTitle } from '@/hooks/usePageTitle';
-import { useServices, useCreateService, useUpdateService, useDeleteService, ServiceFormData as ServiceFormType } from '@/hooks/useServices';
+import { useServices, useCreateService, useUpdateService, useDeleteService, useSeedDefaultServices, ServiceFormData as ServiceFormType } from '@/hooks/useServices';
 import { SectionLoading } from '@/components/ui/loading-spinner';
 
 interface ServiceFormData {
@@ -53,59 +53,12 @@ const ServiceManagement = () => {
   const createServiceMutation = useCreateService();
   const updateServiceMutation = useUpdateService();
   const deleteServiceMutation = useDeleteService();
+  const seedDefaultServices = useSeedDefaultServices();
 
-  const isProcessing = createServiceMutation.isPending || updateServiceMutation.isPending || deleteServiceMutation.isPending;
+  const isProcessing = createServiceMutation.isPending || updateServiceMutation.isPending || deleteServiceMutation.isPending || seedDefaultServices.isPending;
 
-  // Function to seed initial services
-  const seedInitialServices = async () => {
-    const initialServices = [
-      {
-        name: 'Cuci Setrika Regular',
-        description: 'Cuci - Pengeringan - Setrika - Packing',
-        category: 'wash' as const,
-        unit_price: 18000,
-        kilo_price: 6000,
-        supports_unit: true,
-        supports_kilo: true,
-        duration_value: 2,
-        duration_unit: 'days' as const,
-      },
-      {
-        name: 'Express Wash',
-        description: 'Pencucian cepat dalam 24 jam',
-        category: 'wash' as const,
-        unit_price: 25000,
-        kilo_price: 8000,
-        supports_unit: true,
-        supports_kilo: true,
-        duration_value: 1,
-        duration_unit: 'days' as const,
-      },
-      {
-        name: 'Setrika Saja',
-        description: 'Layanan setrika dan pressing saja',
-        category: 'ironing' as const,
-        unit_price: 5000,
-        kilo_price: 3000,
-        supports_unit: true,
-        supports_kilo: true,
-        duration_value: 4,
-        duration_unit: 'hours' as const,
-      },
-    ];
-
-    try {
-      for (const service of initialServices) {
-        await createServiceMutation.mutateAsync(service);
-      }
-      toast({
-        title: "Berhasil",
-        description: "Layanan awal berhasil dibuat",
-      });
-    } catch (error) {
-      console.error('Error seeding services:', error);
-    }
-  };
+  // Seed the shared default starter services (see DEFAULT_SERVICES in useServices).
+  const seedInitialServices = () => seedDefaultServices.mutate();
 
   const getCategoryColor = (category: string) => {
     switch (category) {

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -186,6 +186,81 @@ class AuthService {
     }
   }
 
+  // Decode a JWT payload (base64url) without verifying the signature.
+  // Used to read the Google ID token claims client-side.
+  private decodeJwtPayload(token: string): Record<string, unknown> {
+    const payload = token.split('.')[1];
+    if (!payload) {
+      throw new Error('Invalid token');
+    }
+    const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const json = decodeURIComponent(
+      atob(base64)
+        .split('')
+        .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+        .join('')
+    );
+    return JSON.parse(json);
+  }
+
+  async signInWithGoogle(credential: string): Promise<User> {
+    try {
+      const claims = this.decodeJwtPayload(credential);
+      const email = claims.email as string | undefined;
+      const name = (claims.name as string | undefined) ?? null;
+      const sub = (claims.sub as string | undefined) ?? null;
+
+      if (!email) {
+        throw new Error('Google account did not return an email');
+      }
+
+      const { data, error } = await supabase.rpc('signin_with_google', {
+        google_email: email,
+        google_name: name,
+        google_sub: sub,
+      });
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      if (!data || data.length === 0) {
+        throw new Error('Google sign-in failed');
+      }
+
+      const userData = data[0];
+
+      // Resolve store_id (staff have it on the user row; owners track via stores.owner_id).
+      const { data: userStoreData } = await supabase
+        .from('users')
+        .select('store_id')
+        .eq('id', userData.user_id)
+        .single();
+
+      const user: User = {
+        id: userData.user_id,
+        email: userData.email,
+        full_name: userData.full_name,
+        phone: userData.phone,
+        role: userData.role as 'staff' | 'laundry_owner',
+        store_id: userStoreData?.store_id,
+        is_active: userData.is_active,
+      };
+
+      const session: AuthSession = {
+        user,
+        token: this.generateToken(),
+        expires_at: Date.now() + 24 * 60 * 60 * 1000, // 24 hours
+      };
+
+      this.saveSession(session);
+      return user;
+    } catch (error) {
+      console.error('Google sign in error:', error);
+      throw error;
+    }
+  }
+
   signOut(): void {
     this.clearSession();
   }

--- a/supabase/migrations/20260621000000_seed_default_services_on_store_create.sql
+++ b/supabase/migrations/20260621000000_seed_default_services_on_store_create.sql
@@ -1,0 +1,60 @@
+-- Auto-seed default services whenever a store is created.
+--
+-- Why: A brand-new store starts with zero services, which hard-blocks the POS
+-- (the order screen shows "Belum ada layanan yang dikonfigurasi" and the owner
+-- must manually go set up services before they can create their first order).
+-- Seeding 3 ready-to-use services removes that activation wall so the POS works
+-- immediately after signup. Owners can edit/delete these later.
+--
+-- This updates the create_store(user_id, ...) overload used by the app
+-- (authService.createStoreForUser / createStore) to insert default services in
+-- the same transaction as the store.
+
+CREATE OR REPLACE FUNCTION public.create_store(
+  user_id UUID,
+  store_name TEXT,
+  store_description TEXT DEFAULT NULL,
+  store_address TEXT DEFAULT NULL,
+  store_phone TEXT DEFAULT NULL,
+  store_email TEXT DEFAULT NULL
+)
+RETURNS UUID AS $$
+DECLARE
+  new_store_id UUID;
+  current_user_role TEXT;
+BEGIN
+  -- Check if user has permission to create stores
+  SELECT role INTO current_user_role
+  FROM public.users
+  WHERE id = user_id;
+
+  IF current_user_role != 'laundry_owner' THEN
+    RAISE EXCEPTION 'Only laundry owners can create stores';
+  END IF;
+
+  INSERT INTO public.stores (name, description, address, phone, email, owner_id)
+  VALUES (
+    store_name,
+    store_description,
+    store_address,
+    store_phone,
+    store_email,
+    user_id
+  )
+  RETURNING id INTO new_store_id;
+
+  -- Seed default services so the POS is usable immediately.
+  -- Keep these in sync with DEFAULT_SERVICES in src/hooks/useServices.ts.
+  INSERT INTO public.services
+    (store_id, name, description, category, unit_price, kilo_price, supports_unit, supports_kilo, duration_value, duration_unit, is_active)
+  VALUES
+    (new_store_id, 'Cuci Setrika Regular', 'Cuci - Pengeringan - Setrika - Packing', 'wash', 18000, 6000, true, true, 2, 'days', true),
+    (new_store_id, 'Express Wash', 'Pencucian cepat dalam 24 jam', 'wash', 25000, 8000, true, true, 1, 'days', true),
+    (new_store_id, 'Setrika Saja', 'Layanan setrika dan pressing saja', 'ironing', 5000, 3000, true, true, 4, 'hours', true);
+
+  RETURN new_store_id;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.create_store(UUID, TEXT, TEXT, TEXT, TEXT, TEXT) IS
+  'Creates a store for a laundry_owner and seeds 3 default services so the POS is usable immediately after signup.';

--- a/supabase/migrations/20260621000001_add_google_signin.sql
+++ b/supabase/migrations/20260621000001_add_google_signin.sql
@@ -1,0 +1,88 @@
+-- Google Sign-In support for the custom (non-Supabase-Auth) auth system.
+--
+-- Flow: the client obtains a Google ID token via @react-oauth/google, decodes
+-- it for email/name/sub, then calls signin_with_google(). This RPC:
+--   * logs in an existing user matched by email, OR
+--   * creates a brand-new user as a laundry_owner, auto-creates a store named
+--     "Toko {name}" (which seeds default services via create_store), and logs
+--     them in.
+--
+-- Note: the Google ID token is not cryptographically verified server-side here;
+-- this matches the app's existing custom-auth trust model. Move verification to
+-- an edge function if stronger guarantees are required.
+
+-- Track the Google account identifier so the same Google user maps to one row.
+ALTER TABLE public.users ADD COLUMN IF NOT EXISTS google_sub TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_google_sub
+  ON public.users(google_sub) WHERE google_sub IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.signin_with_google(
+  google_email TEXT,
+  google_name TEXT DEFAULT NULL,
+  google_sub TEXT DEFAULT NULL
+)
+RETURNS TABLE(
+  user_id UUID,
+  email TEXT,
+  full_name TEXT,
+  phone TEXT,
+  role TEXT,
+  is_active BOOLEAN,
+  is_new BOOLEAN
+) AS $$
+DECLARE
+  existing_user public.users%ROWTYPE;
+  new_user_id UUID;
+  resolved_name TEXT;
+BEGIN
+  IF google_email IS NULL OR length(trim(google_email)) = 0 THEN
+    RAISE EXCEPTION 'Google email is required';
+  END IF;
+
+  -- Match existing accounts by email (case-insensitive).
+  SELECT * INTO existing_user
+  FROM public.users u
+  WHERE lower(u.email) = lower(google_email)
+  LIMIT 1;
+
+  IF FOUND THEN
+    IF NOT existing_user.is_active THEN
+      RAISE EXCEPTION 'Account is inactive';
+    END IF;
+
+    -- Backfill the Google identifier on first Google login for this account.
+    IF existing_user.google_sub IS NULL AND google_sub IS NOT NULL THEN
+      UPDATE public.users SET google_sub = signin_with_google.google_sub
+      WHERE id = existing_user.id;
+    END IF;
+
+    RETURN QUERY
+    SELECT existing_user.id, existing_user.email, existing_user.full_name,
+           existing_user.phone, existing_user.role, existing_user.is_active, false;
+    RETURN;
+  END IF;
+
+  -- New user: create as a laundry owner with an unusable password (Google-only login).
+  resolved_name := COALESCE(NULLIF(trim(google_name), ''), split_part(google_email, '@', 1));
+
+  INSERT INTO public.users (email, password_hash, full_name, role, google_sub, is_active)
+  VALUES (
+    google_email,
+    crypt(gen_random_uuid()::text, gen_salt('bf', 12)),
+    resolved_name,
+    'laundry_owner',
+    signin_with_google.google_sub,
+    true
+  )
+  RETURNING id INTO new_user_id;
+
+  -- Auto-create a store (seeds default services) so the POS is usable immediately.
+  PERFORM public.create_store(new_user_id, 'Toko ' || resolved_name);
+
+  RETURN QUERY
+  SELECT new_user_id, google_email, resolved_name, NULL::TEXT, 'laundry_owner'::TEXT, true, true;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.signin_with_google(TEXT, TEXT, TEXT) IS
+  'Logs in or registers a user via Google. New users become laundry_owners with an auto-created, service-seeded store.';


### PR DESCRIPTION
## Summary
Two workstreams aimed at turning logged-in users into **active POS users**, plus a faster signup path via Google.

### 1. POS activation (closing the first-order gap)
New owners previously logged in, hit a zeroed dashboard, and dead-ended on the POS "no services configured" notice — so many never created an order. This removes that wall:

- **Auto-seed default services on store creation** — `create_store()` now inserts 3 ready-to-use services in the same transaction, so the POS works immediately after signup.
- **One-tap seed inside the POS** — the orange empty-state notice gets a **"Muat Contoh Layanan"** button, so users get unblocked without leaving the order screen.
- **HomePage "Mulai Cepat" checklist** — stores with no orders see a getting-started checklist (progress bar, steps, dominant **"Buat Pesanan Pertama"** CTA) instead of the demotivating Rp0 cards. Auto-reverts to the normal dashboard once the first order exists.
- Shared `DEFAULT_SERVICES` + `useSeedDefaultServices` hook; `ServiceManagement` refactored to use it (removed duplicated seed array).

### 2. Google Sign-In
Integrated with the existing **custom localStorage auth** (not Supabase Auth), per the chosen approach: client-side ID-token decode + RPC upsert.

- `@react-oauth/google` button on the login/signup tabs; **hidden when `VITE_GOOGLE_CLIENT_ID` is unset** (app unchanged without config).
- `authService.signInWithGoogle()` decodes the Google ID token and upserts via a new `signin_with_google` RPC.
- **New Google users** become `laundry_owner`s with an auto-created, service-seeded store ("Toko {name}").
- Adds `google_sub` column + `signin_with_google` migration; documents `VITE_GOOGLE_CLIENT_ID` in `.env.example`.

## Migrations (must be applied)
- `20260621000000_seed_default_services_on_store_create.sql`
- `20260621000001_add_google_signin.sql`

Both are idempotent (`IF NOT EXISTS` / `CREATE OR REPLACE`). ✅ Already applied & verified on the production Supabase project.

## Deploy checklist
- [ ] Apply both migrations to each target environment
- [ ] Set `VITE_GOOGLE_CLIENT_ID` in Vercel (currently only in local env)
- [ ] Add production domain to **Authorized JavaScript origins** in Google Cloud Console

## Notes / trade-offs
- The Google ID token is decoded client-side, **not** verified server-side — consistent with the app's existing custom-auth trust model. Migration comments flag where to add an edge-function verifier if stronger guarantees are wanted later.
- Activation checklist refetches on ~60s staleness/window-focus, so it may take a refocus to flip to the dashboard right after the very first order.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` passes
- [x] `eslint` clean on new files
- [ ] Google sign-in end-to-end (blocked locally only on Google Console origin propagation — config, not code)
- [ ] New store → checklist shows → first order flips to dashboard
- [ ] Empty POS → "Muat Contoh Layanan" seeds services in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Google Sign-In is now available on the login page for quick account creation and authentication
* New activation checklist displays store setup progress with completion status and actionable next steps
* Default laundry services are automatically created for newly established stores

<!-- end of auto-generated comment: release notes by coderabbit.ai -->