### PR TITLE
Onboarding polish: focused home + action-driven welcome tour

### DIFF
--- a/src/components/ui/coachmark.tsx
+++ b/src/components/ui/coachmark.tsx
@@ -11,9 +11,8 @@ import { Button } from '@/components/ui/button';
 import { 
   Plus, 
   Users, 
-  ShoppingCart, 
-  BarChart3, 
-  Wrench,
+  ShoppingCart,
+  BarChart3,
   Home,
   ChevronLeft,
   ChevronRight,
@@ -31,12 +30,14 @@ interface CoachmarkStep {
 interface CoachmarkProps {
   open: boolean;
   onClose: () => void;
+  /** Called when the user finishes the tour via the final action CTA. */
+  onStart?: () => void;
 }
 
 const coachmarkSteps: CoachmarkStep[] = [
   {
     title: 'Selamat Datang di Smart Laundry POS! 🎉',
-    description: 'Kami akan memandu Anda melalui fitur-fitur utama aplikasi untuk membantu Anda memulai dengan mudah. Mari kita mulai!',
+    description: 'Kami akan memandu Anda melalui fitur-fitur utama. Di beranda ada checklist "Mulai Cepat" yang memandu Anda menyiapkan toko langkah demi langkah. Mari kita mulai!',
     icon: Home,
     iconColor: 'text-rose-500',
     iconBgColor: 'bg-rose-100'
@@ -70,17 +71,17 @@ const coachmarkSteps: CoachmarkStep[] = [
     iconBgColor: 'bg-orange-100'
   },
   {
-    title: 'Kelola Layanan (Khusus Pemilik)',
-    description: 'Sebagai pemilik toko, Anda dapat menambah dan mengedit layanan laundry, mengatur harga, dan mengelola kategori layanan dari menu "Layanan".',
-    icon: Wrench,
-    iconColor: 'text-indigo-500',
-    iconBgColor: 'bg-indigo-100'
+    title: 'Siap Memulai? 🚀',
+    description: 'Ikuti checklist "Mulai Cepat" di beranda untuk menyiapkan toko, atau langsung buat pesanan pertama Anda sekarang.',
+    icon: Plus,
+    iconColor: 'text-rose-500',
+    iconBgColor: 'bg-rose-100'
   }
 ];
 
 const COACHMARK_STORAGE_KEY = 'smart-laundry-coachmark-shown';
 
-export const Coachmark: React.FC<CoachmarkProps> = ({ open, onClose }) => {
+export const Coachmark: React.FC<CoachmarkProps> = ({ open, onClose, onStart }) => {
   const [currentStep, setCurrentStep] = useState(0);
 
   const isLastStep = currentStep === coachmarkSteps.length - 1;
@@ -105,6 +106,8 @@ export const Coachmark: React.FC<CoachmarkProps> = ({ open, onClose }) => {
     localStorage.setItem(COACHMARK_STORAGE_KEY, 'true');
     onClose();
     setCurrentStep(0);
+    // Drive the user straight into their first task instead of dead-ending.
+    onStart?.();
   };
 
   const handleSkip = () => {
@@ -178,7 +181,8 @@ export const Coachmark: React.FC<CoachmarkProps> = ({ open, onClose }) => {
               onClick={handleNext}
               className="flex-1 bg-rose-500 hover:bg-rose-600"
             >
-              {isLastStep ? 'Selesai' : 'Lanjut'}
+              {isLastStep && <Plus className="h-4 w-4 mr-1" />}
+              {isLastStep ? 'Buat Pesanan Pertama' : 'Lanjut'}
               {!isLastStep && <ChevronRight className="h-4 w-4 ml-1" />}
             </Button>
           </div>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -170,6 +170,13 @@ export const HomePage: React.FC = () => {
     }
   ].filter(action => !action.hidden);
 
+  // Grid excludes "new-order" (promoted to a full-width hero button) and, for
+  // new stores, hides the disabled "coming soon" tiles so the grid only shows
+  // functional actions.
+  const gridActions = quickActions.filter(
+    (action) => action.id !== 'new-order' && !(showOnboarding && action.disabled)
+  );
+
   const bottomNavItems = [
     {
       id: 'home',
@@ -205,7 +212,7 @@ export const HomePage: React.FC = () => {
   return (
     <div className="min-h-screen bg-gray-50 pb-20">
       {/* Coachmark */}
-      <Coachmark open={shouldShowCoachmark} onClose={hideCoachmark} />
+      <Coachmark open={shouldShowCoachmark} onClose={hideCoachmark} onStart={() => navigate('/pos')} />
       
       {/* Header with coral/salmon background */}
       <div className="bg-gradient-to-r from-rose-400 to-rose-500 text-white px-4 pt-8 pb-12 rounded-b-3xl shadow-lg">
@@ -324,9 +331,20 @@ export const HomePage: React.FC = () => {
           </div>
         )}
 
+        {/* Primary action: full-width hero. New stores use the checklist CTA instead. */}
+        {!showOnboarding && (
+          <button
+            onClick={() => navigate('/pos')}
+            className="mt-6 flex w-full items-center justify-center gap-2 rounded-2xl bg-rose-500 px-4 py-4 font-semibold text-white shadow-md transition-shadow hover:shadow-lg active:scale-[0.99]"
+          >
+            <Plus className="h-5 w-5" />
+            Buat Pesanan Baru
+          </button>
+        )}
+
         {/* Quick Actions Grid */}
         <div className="grid grid-cols-3 gap-3 mt-6">
-          {quickActions.map((action) => (
+          {gridActions.map((action) => (
             <button
               key={action.id}
               onClick={action.onClick}


### PR DESCRIPTION
## Summary
Follow-up onboarding polish on top of #134 (POS activation + Google Sign-In). Two small, high-impact UX changes that sharpen the first-run experience for new stores.

### 1. Focus the home screen (`HomePage.tsx`)
- **"Buat Pesanan" promoted to a full-width hero button** for activated stores (new stores already get the activation checklist's CTA — no duplicate).
- **Removed the redundant "Buat Pesanan" tile** from the quick-actions grid.
- **Hide the disabled "coming soon" tiles** (Scan QR, Metode Pembayaran) **for new stores**, so a first-time owner sees only functional actions instead of a half-broken grid. Activated stores keep them (unchanged behavior).

### 2. Action-driven welcome tour (`coachmark.tsx`)
- Final step is now a real **"Buat Pesanan Pertama"** CTA that completes the tour **and navigates to `/pos`** (new `onStart` callback), instead of dead-ending on "Selesai".
- **De-duped against the activation checklist:** the welcome step points users to the "Mulai Cepat" checklist, and the redundant owner-only "Kelola Layanan" step (already covered by the checklist) was replaced with a "Siap Memulai?" action-closer.

## Result
For a **new store**: welcome tour ends by dropping the user into order creation → home shows the activation checklist + a tight grid of only working actions. For an **activated store**: revenue cards → hero "Buat Pesanan Baru" → full grid.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` passes
- [x] `eslint` clean (one pre-existing `react-refresh/only-export-components` warning — `coachmark.tsx` exports both the component and the `useCoachmark` hook; not introduced here)
- [ ] New store: tour final CTA navigates to /pos; home grid hides "coming soon" tiles
- [ ] Activated store: hero "Buat Pesanan Baru" shows; grid unchanged

## Commits
1. `feat(home): focus the home screen for new stores`
2. `feat(onboarding): action-driven welcome tour`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced onboarding experience with improved tour messaging and navigation flow to POS.
  * Added prominent "Create First Order" button for new stores to streamline initial setup.
  
* **Improvements**
  * Updated onboarding tour with new step messaging and clearer call-to-action.
  * Refined quick actions display to better guide new users through their first task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->