### PR TITLE
Store management: mobile layout fix + edit store details

### DIFF
--- a/src/components/stores/StoreDetailsCard.tsx
+++ b/src/components/stores/StoreDetailsCard.tsx
@@ -1,0 +1,183 @@
+import React, { useState, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { toast } from '@/hooks/use-toast';
+import { supabase } from '@/integrations/supabase/client';
+import { useStore } from '@/contexts/StoreContext';
+import { Store, Save } from 'lucide-react';
+import { LoadingSpinner } from '@/components/ui/loading-spinner';
+
+interface StoreDetailsForm {
+  name: string;
+  address: string;
+  phone: string;
+}
+
+/**
+ * Lets a store owner edit the current store's name, address and phone number.
+ * Writes to the `stores` table and refreshes StoreContext so the change is
+ * reflected across the app (header, home, receipts).
+ */
+export const StoreDetailsCard: React.FC = () => {
+  const { currentStore, isOwner, refreshStores } = useStore();
+  const [form, setForm] = useState<StoreDetailsForm>({ name: '', address: '', phone: '' });
+  const [saving, setSaving] = useState(false);
+
+  // Sync the form whenever the selected/current store changes.
+  useEffect(() => {
+    if (currentStore) {
+      setForm({
+        name: currentStore.store_name || '',
+        address: currentStore.store_address || '',
+        phone: currentStore.store_phone || '',
+      });
+    }
+  }, [currentStore?.store_id, currentStore?.store_name, currentStore?.store_address, currentStore?.store_phone]);
+
+  if (!currentStore) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-8">
+          <p className="text-muted-foreground">Tidak ada toko yang dipilih</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!isOwner) {
+    return (
+      <Card>
+        <CardContent className="flex items-center justify-center py-8">
+          <p className="text-muted-foreground">Hanya pemilik toko yang dapat mengubah detail toko</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const isDirty =
+    form.name.trim() !== (currentStore.store_name || '') ||
+    form.address.trim() !== (currentStore.store_address || '') ||
+    form.phone.trim() !== (currentStore.store_phone || '');
+
+  const handleSave = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!currentStore.store_id || !isOwner) return;
+
+    if (!form.name.trim()) {
+      toast({
+        title: 'Error',
+        description: 'Nama toko wajib diisi',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    try {
+      setSaving(true);
+      const { error } = await supabase
+        .from('stores')
+        .update({
+          name: form.name.trim(),
+          address: form.address.trim() || null,
+          phone: form.phone.trim() || null,
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', currentStore.store_id);
+
+      if (error) {
+        console.error('Error updating store details:', error);
+        toast({
+          title: 'Error',
+          description: 'Gagal menyimpan detail toko',
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      await refreshStores();
+      toast({
+        title: 'Tersimpan',
+        description: 'Detail toko berhasil diperbarui',
+      });
+    } catch (error) {
+      console.error('Error updating store details:', error);
+      toast({
+        title: 'Error',
+        description: 'Gagal menyimpan detail toko',
+        variant: 'destructive',
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg sm:text-2xl">
+          <Store className="h-5 w-5 flex-shrink-0" />
+          Detail Toko
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSave} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="store-name">Nama Toko</Label>
+            <Input
+              id="store-name"
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              placeholder="Masukkan nama toko"
+              required
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="store-address">Alamat</Label>
+            <Input
+              id="store-address"
+              type="text"
+              value={form.address}
+              onChange={(e) => setForm({ ...form, address: e.target.value })}
+              placeholder="Masukkan alamat toko"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="store-phone">Nomor Telepon</Label>
+            <Input
+              id="store-phone"
+              type="tel"
+              value={form.phone}
+              onChange={(e) => setForm({ ...form, phone: e.target.value })}
+              placeholder="Masukkan nomor telepon toko"
+            />
+          </div>
+
+          <div className="flex justify-end pt-2">
+            <Button
+              type="submit"
+              disabled={saving || !isDirty}
+              className="flex items-center gap-2 w-full sm:w-auto"
+            >
+              {saving ? (
+                <>
+                  <LoadingSpinner size="sm" variant="white" />
+                  Menyimpan...
+                </>
+              ) : (
+                <>
+                  <Save className="h-4 w-4" />
+                  Simpan Perubahan
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/stores/StoreManagement.tsx
+++ b/src/components/stores/StoreManagement.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useStore } from '@/contexts/StoreContext';
 import { CreateStoreDialog } from './CreateStoreDialog';
+import { StoreDetailsCard } from './StoreDetailsCard';
 import { StoreStaffManagement } from './StoreStaffManagement';
 import { StoreSettingsCard } from './StoreSettingsCard';
 import { Building2, Users, TrendingUp, Package } from 'lucide-react';
@@ -122,6 +123,7 @@ export const StoreManagement: React.FC = () => {
 
       {selectedStore && (
         <div className="space-y-4 sm:space-y-6">
+          <StoreDetailsCard />
           <StoreStaffManagement store={selectedStore} />
           <StoreSettingsCard />
         </div>

--- a/src/components/stores/StoreStaffManagement.tsx
+++ b/src/components/stores/StoreStaffManagement.tsx
@@ -188,15 +188,15 @@ export const StoreStaffManagement: React.FC<StoreStaffManagementProps> = ({ stor
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Users className="h-5 w-5" />
-            Manajemen Staf - {store.store_name}
-          </div>
-          <div className="flex gap-2 flex-wrap">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <CardTitle className="flex min-w-0 items-center gap-2 text-lg sm:text-2xl">
+            <Users className="h-5 w-5 flex-shrink-0" />
+            <span className="truncate">Manajemen Staf - {store.store_name}</span>
+          </CardTitle>
+          <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-shrink-0 sm:flex-wrap">
             <Dialog open={assignDialogOpen} onOpenChange={setAssignDialogOpen}>
               <DialogTrigger asChild>
-                <Button variant="outline" size="sm">
+                <Button variant="outline" size="sm" className="w-full sm:w-auto">
                   Tugaskan yang Ada
                 </Button>
               </DialogTrigger>
@@ -241,7 +241,7 @@ export const StoreStaffManagement: React.FC<StoreStaffManagementProps> = ({ stor
 
             <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
               <DialogTrigger asChild>
-                <Button size="sm">
+                <Button size="sm" className="w-full sm:w-auto">
                   <UserPlus className="h-4 w-4 mr-2" />
                   Tambah Staf Baru
                 </Button>
@@ -306,7 +306,7 @@ export const StoreStaffManagement: React.FC<StoreStaffManagementProps> = ({ stor
               </DialogContent>
             </Dialog>
           </div>
-        </CardTitle>
+        </div>
       </CardHeader>
       <CardContent>
         {loading && staff.length === 0 ? (

--- a/src/contexts/StoreContext.tsx
+++ b/src/contexts/StoreContext.tsx
@@ -71,8 +71,7 @@ export const StoreProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       if (persistedStoreId) {
         // Check if persisted store is still accessible
         targetStore = stores.find(s => s.store_id === persistedStoreId) || null;
-        if (targetStore) {
-        } else {
+        if (!targetStore) {
           persistStoreId(null);
         }
       }
@@ -83,9 +82,14 @@ export const StoreProvider: React.FC<{ children: React.ReactNode }> = ({ childre
       // 3. First available store
       if (stores.length > 0) {
         setCurrentStore(currentStoreState => {
-          // Priority 1: Keep current store if it's still in the list
-          if (currentStoreState && stores.find(s => s.store_id === currentStoreState.store_id)) {
-            return currentStoreState;
+          // Priority 1: Keep current store if it's still in the list. Use the
+          // freshly fetched record (not the stale state) so edits to the store's
+          // name/address/phone are reflected everywhere after a refresh.
+          const refreshedCurrent = currentStoreState
+            ? stores.find(s => s.store_id === currentStoreState.store_id)
+            : undefined;
+          if (refreshedCurrent) {
+            return refreshedCurrent;
           }
           
           // Priority 2: Use persisted store if available


### PR DESCRIPTION
## Summary
Two store-management improvements.

### 1. Fix: staff section header layout on mobile (`StoreStaffManagement.tsx`)
The staff header crammed the large `text-2xl` title and both action buttons into one `justify-between` row **inside the `<h3>`** with no wrapping, so on mobile the long "Manajemen Staf - {store name}" title and the buttons **overlapped**.
- Header stacks vertically on mobile (`flex-col`), inline on desktop.
- Title is `text-lg` on mobile / `text-2xl` on desktop; store name **truncates**.
- Buttons moved out of the `<h3>`; laid out as a 2-col grid of equal full-width buttons on mobile, inline auto-width on desktop. No overlap, bigger tap targets.

### 2. Feature: edit store name, address & phone (`StoreDetailsCard.tsx`)
New **"Detail Toko"** card in store management (first in the details section, above Staff & Settings):
- Owner-only form, pre-filled from the current store; edits **name** (required), **address**, **phone**.
- Saves to the `stores` table, then refreshes `StoreContext`. **Save is disabled until a field changes.**

**Bug fix (`StoreContext.tsx`):** `refreshStores` returned the **stale** current-store object when the store still existed, so edited details wouldn't show in the header/home/receipts until a full reload. Now it returns the freshly-fetched record. Also cleaned an adjacent empty-`if` (`no-empty`) in the same function.

## Result
Owners can update their store's name/address/phone in-app, and the change propagates everywhere immediately. The staff section no longer overlaps on mobile.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` passes
- [x] `eslint` — resolved the `no-empty` error; remaining warnings are pre-existing (context provider+hook export; intentional field-level effect deps)
- [ ] Mobile: staff header title + buttons no longer overlap
- [ ] Edit store name/address/phone → saves → header & home reflect it without reload

## Commits
1. `fix(stores): staff section header layout on mobile`
2. `feat(stores): edit store name, address and phone`

🤖 Generated with [Claude Code](https://claude.com/claude-code)