### PR TITLE
Fix: persist store detail edits + staff button overflow on mobile

### DIFF
--- a/src/components/stores/StoreDetailsCard.tsx
+++ b/src/components/stores/StoreDetailsCard.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { toast } from '@/hooks/use-toast';
-import { supabase } from '@/integrations/supabase/client';
+import { authService } from '@/services/authService';
 import { useStore } from '@/contexts/StoreContext';
 import { Store, Save } from 'lucide-react';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
@@ -76,25 +76,11 @@ export const StoreDetailsCard: React.FC = () => {
 
     try {
       setSaving(true);
-      const { error } = await supabase
-        .from('stores')
-        .update({
-          name: form.name.trim(),
-          address: form.address.trim() || null,
-          phone: form.phone.trim() || null,
-          updated_at: new Date().toISOString(),
-        })
-        .eq('id', currentStore.store_id);
-
-      if (error) {
-        console.error('Error updating store details:', error);
-        toast({
-          title: 'Error',
-          description: 'Gagal menyimpan detail toko',
-          variant: 'destructive',
-        });
-        return;
-      }
+      await authService.updateStore(currentStore.store_id, {
+        name: form.name.trim(),
+        address: form.address.trim() || null,
+        phone: form.phone.trim() || null,
+      });
 
       await refreshStores();
       toast({

--- a/src/components/stores/StoreStaffManagement.tsx
+++ b/src/components/stores/StoreStaffManagement.tsx
@@ -193,7 +193,7 @@ export const StoreStaffManagement: React.FC<StoreStaffManagementProps> = ({ stor
             <Users className="h-5 w-5 flex-shrink-0" />
             <span className="truncate">Manajemen Staf - {store.store_name}</span>
           </CardTitle>
-          <div className="grid grid-cols-2 gap-2 sm:flex sm:flex-shrink-0 sm:flex-wrap">
+          <div className="grid grid-cols-1 gap-2 sm:flex sm:flex-shrink-0 sm:flex-wrap">
             <Dialog open={assignDialogOpen} onOpenChange={setAssignDialogOpen}>
               <DialogTrigger asChild>
                 <Button variant="outline" size="sm" className="w-full sm:w-auto">

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -324,6 +324,29 @@ class AuthService {
     return data;
   }
 
+  async updateStore(
+    storeId: string,
+    storeData: { name: string; address?: string | null; phone?: string | null }
+  ): Promise<void> {
+    if (!this.isAuthenticated()) {
+      throw new Error('User not authenticated');
+    }
+
+    // Uses a SECURITY DEFINER RPC because RLS blocks direct stores updates under
+    // the app's custom auth (auth.uid() is null).
+    const { error } = await supabase.rpc('update_store', {
+      user_id: this.session!.user.id,
+      target_store_id: storeId,
+      store_name: storeData.name,
+      store_address: storeData.address ?? null,
+      store_phone: storeData.phone ?? null,
+    });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  }
+
   async assignStaffToStore(staffUserId: string, storeId: string): Promise<boolean> {
     if (!this.isAuthenticated()) {
       throw new Error('User not authenticated');

--- a/supabase/migrations/20260622000000_add_update_store_function.sql
+++ b/supabase/migrations/20260622000000_add_update_store_function.sql
@@ -1,0 +1,49 @@
+-- Allow store owners to edit their store's name/address/phone.
+--
+-- Why an RPC: the app uses custom (non-Supabase-Auth) auth, so auth.uid() is
+-- NULL in RLS. The stores UPDATE policy ("Store owners can manage their stores")
+-- therefore evaluates false for the anon role, and a direct
+-- supabase.from('stores').update(...) silently updates 0 rows. This mirrors the
+-- existing create_store / assign_staff_to_store SECURITY DEFINER pattern, which
+-- bypasses RLS and verifies ownership in the function body instead.
+
+CREATE OR REPLACE FUNCTION public.update_store(
+  user_id UUID,
+  target_store_id UUID,
+  store_name TEXT,
+  store_address TEXT DEFAULT NULL,
+  store_phone TEXT DEFAULT NULL
+)
+RETURNS BOOLEAN AS $$
+DECLARE
+  store_owner_id UUID;
+BEGIN
+  IF store_name IS NULL OR length(trim(store_name)) = 0 THEN
+    RAISE EXCEPTION 'Store name is required';
+  END IF;
+
+  SELECT owner_id INTO store_owner_id
+  FROM public.stores
+  WHERE id = target_store_id;
+
+  IF store_owner_id IS NULL THEN
+    RAISE EXCEPTION 'Store not found';
+  END IF;
+
+  IF store_owner_id <> user_id THEN
+    RAISE EXCEPTION 'Only the store owner can update this store';
+  END IF;
+
+  UPDATE public.stores
+  SET name = trim(store_name),
+      address = NULLIF(trim(COALESCE(store_address, '')), ''),
+      phone = NULLIF(trim(COALESCE(store_phone, '')), ''),
+      updated_at = now()
+  WHERE id = target_store_id;
+
+  RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.update_store(UUID, UUID, TEXT, TEXT, TEXT) IS
+  'Updates a store''s name/address/phone after verifying the caller owns it. SECURITY DEFINER to work with the app''s custom auth.';


### PR DESCRIPTION
Follow-up fixes to #136.

## 1. Store detail edits weren't saving (`update_store` RPC)
`StoreDetailsCard` did a direct `supabase.from('stores').update(...)`, which **silently updated 0 rows**: the app uses custom (non-Supabase-Auth) auth, so `auth.uid()` is null and the `stores` UPDATE RLS policy evaluates false for the anon role. The UI showed a success toast but nothing persisted, and the form reset to the old values on reload.

**Verified against prod:** anon `SELECT` on `stores` works, but `PATCH` returns `[]` (0 rows) — RLS blocks it.

Fix (mirrors `create_store` / `assign_staff_to_store`):
- New **`update_store()` `SECURITY DEFINER` RPC** that verifies the caller owns the store, then updates name/address/phone.
- `authService.updateStore()` calls the RPC; `StoreDetailsCard` uses it instead of a direct table write.

## 2. "Tambah Staf Baru" button text overflow on mobile
The 2-column button grid made each button ~half-width; the button's `whitespace-nowrap` text overflowed past the edge and was unreadable. Now the two action buttons **stack full-width on mobile** (`grid-cols-1`), inline auto-width on desktop.

## ⚠️ Migration required
`supabase/migrations/20260622000000_add_update_store_function.sql` must be applied to each environment (idempotent `CREATE OR REPLACE`). Until applied, saving store details will error with "function update_store not found".

## Related (not in this PR)
`StoreSettingsCard` (QR / points toggles) uses the same direct-update pattern and has the **same latent RLS bug** — its toggles also won't persist under custom auth. Flagging for a follow-up.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` passes
- [ ] Apply migration → edit store name/address/phone → persists after reload
- [ ] Mobile: staff action buttons readable, no overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)