### PR TITLE
SEO: fix canonical domain + strengthen on-page metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
     <meta name="geo.region" content="ID" />
     <meta name="geo.country" content="Indonesia" />
 
+    <!-- Canonical URL -->
+    <link rel="canonical" href="https://pos.fahrudina.my.id/" />
+
     <!-- Facebook Domain Verification -->
     <meta name="facebook-domain-verification" content="ufj37m1gh59erdsalp13ml6n8kdp5h" />
 
@@ -45,44 +48,73 @@
     <meta property="og:title" content="Smart Laundry POS - Sistem Kasir Modern untuk Laundry Indonesia" />
     <meta property="og:description" content="Kelola bisnis laundry Anda dengan sistem POS modern. Mobile-friendly, cloud-based, dan mudah digunakan. Hubungi: fahrudinjaya@gmail.com" />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://smart-laundry-pos.vercel.app" />
-    <meta property="og:image" content="/favicon-512.png" />
+    <meta property="og:url" content="https://pos.fahrudina.my.id/" />
+    <meta property="og:image" content="https://pos.fahrudina.my.id/favicon-512.png" />
+    <meta property="og:image:width" content="512" />
+    <meta property="og:image:height" content="512" />
+    <meta property="og:image:alt" content="Smart Laundry POS - Sistem Kasir Laundry" />
     <meta property="og:locale" content="id_ID" />
     <meta property="og:site_name" content="Smart Laundry POS" />
-    
+
     <!-- Twitter Card Meta Tags -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Smart Laundry POS - Sistem Kasir Modern untuk Laundry" />
     <meta name="twitter:description" content="Sistem POS terbaik untuk bisnis laundry di Indonesia. Kontak: fahrudinjaya@gmail.com" />
-    <meta name="twitter:image" content="/favicon-512.png" />
+    <meta name="twitter:image" content="https://pos.fahrudina.my.id/favicon-512.png" />
     
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
-      "@type": "SoftwareApplication",
-      "name": "Smart Laundry POS",
-      "description": "Sistem Point of Sale modern untuk bisnis laundry di Indonesia",
-      "url": "https://smart-laundry-pos.vercel.app",
-      "applicationCategory": "BusinessApplication",
-      "operatingSystem": "Web Browser, Android, iOS",
-      "offers": {
-        "@type": "Offer",
-        "price": "0",
-        "priceCurrency": "IDR"
-      },
-      "creator": {
-        "@type": "Person",
-        "name": "Smart Laundry POS",
-        "email": "fahrudinjaya@gmail.com"
-      },
-      "featureList": [
-        "Manajemen Pesanan",
-        "Database Pelanggan", 
-        "Proses Pembayaran",
-        "Laporan Analitik",
-        "Dukungan Multi-toko",
-        "Mode Offline"
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "https://pos.fahrudina.my.id/#website",
+          "name": "Smart Laundry POS",
+          "url": "https://pos.fahrudina.my.id/",
+          "inLanguage": "id-ID",
+          "publisher": { "@id": "https://pos.fahrudina.my.id/#organization" }
+        },
+        {
+          "@type": "Organization",
+          "@id": "https://pos.fahrudina.my.id/#organization",
+          "name": "Smart Laundry POS",
+          "url": "https://pos.fahrudina.my.id/",
+          "logo": "https://pos.fahrudina.my.id/favicon-512.png",
+          "email": "fahrudinjaya@gmail.com",
+          "contactPoint": {
+            "@type": "ContactPoint",
+            "email": "fahrudinjaya@gmail.com",
+            "contactType": "customer support",
+            "availableLanguage": ["Indonesian"]
+          }
+        },
+        {
+          "@type": "SoftwareApplication",
+          "name": "Smart Laundry POS",
+          "description": "Sistem Point of Sale modern untuk bisnis laundry di Indonesia. Kelola pesanan, pelanggan, pembayaran, dan poin loyalitas dengan mudah.",
+          "url": "https://pos.fahrudina.my.id/",
+          "image": "https://pos.fahrudina.my.id/favicon-512.png",
+          "inLanguage": "id-ID",
+          "applicationCategory": "BusinessApplication",
+          "operatingSystem": "Web Browser, Android, iOS",
+          "browserRequirements": "Requires JavaScript. Requires HTML5.",
+          "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "IDR"
+          },
+          "creator": { "@id": "https://pos.fahrudina.my.id/#organization" },
+          "featureList": [
+            "Manajemen Pesanan",
+            "Database Pelanggan",
+            "Proses Pembayaran",
+            "Laporan Analitik",
+            "Dukungan Multi-toko",
+            "Sistem Poin Loyalitas",
+            "Mode Offline"
+          ]
+        }
       ]
     }
     </script>
@@ -91,6 +123,31 @@
 
   <body>
     <div id="root"></div>
+    <noscript>
+      <section style="max-width:640px;margin:0 auto;padding:24px;font-family:system-ui,sans-serif;">
+        <h1>Smart Laundry POS - Sistem Kasir Modern untuk Laundry Indonesia</h1>
+        <p>
+          Smart Laundry POS adalah sistem Point of Sale (POS) berbasis cloud untuk
+          bisnis laundry di Indonesia. Kelola pesanan, pelanggan, pembayaran, poin
+          loyalitas, dan laporan dari ponsel maupun desktop. Bisa diinstal seperti
+          aplikasi (PWA) dan mendukung mode offline.
+        </p>
+        <h2>Fitur Utama</h2>
+        <ul>
+          <li>Manajemen pesanan laundry (kiloan, satuan, kombinasi)</li>
+          <li>Database pelanggan dan riwayat transaksi</li>
+          <li>Pembayaran dan struk digital</li>
+          <li>Sistem poin loyalitas pelanggan</li>
+          <li>Dukungan multi-toko untuk pemilik usaha</li>
+          <li>Laporan pendapatan dan pengeluaran</li>
+        </ul>
+        <p>
+          Aplikasi ini membutuhkan JavaScript. Silakan aktifkan JavaScript, atau
+          <a href="https://pos.fahrudina.my.id/login">masuk ke aplikasi</a>.
+        </p>
+        <p>Kontak: fahrudinjaya@gmail.com</p>
+      </section>
+    </noscript>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -13,13 +13,20 @@ Allow: /
 User-agent: *
 Allow: /
 Allow: /login
+Allow: /install
+Disallow: /home
 Disallow: /pos
 Disallow: /order-history
+Disallow: /customers
 Disallow: /services
 Disallow: /stores
+Disallow: /expenses
+Disallow: /revenue-report
+Disallow: /whatsapp-broadcast
+Disallow: /receipt/
 
 # Sitemap
-Sitemap: https://smart-laundry-pos.vercel.app/sitemap.xml
+Sitemap: https://pos.fahrudina.my.id/sitemap.xml
 
 # Contact Information
 # Email: fahrudinjaya@gmail.com

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,15 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://smart-laundry-pos.vercel.app/</loc>
-    <lastmod>2025-08-03</lastmod>
+    <loc>https://pos.fahrudina.my.id/</loc>
+    <lastmod>2026-06-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://smart-laundry-pos.vercel.app/login</loc>
-    <lastmod>2025-08-03</lastmod>
+    <loc>https://pos.fahrudina.my.id/login</loc>
+    <lastmod>2026-06-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://pos.fahrudina.my.id/install</loc>
+    <lastmod>2026-06-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
   </url>
 </urlset>

--- a/src/integrations/whatsapp/templates.ts
+++ b/src/integrations/whatsapp/templates.ts
@@ -16,7 +16,7 @@ const getReceiptBaseUrl = (): string => {
   }
   
   // Fallback for server-side rendering or build time
-  return 'https://smart-laundry-pos.vercel.app';
+  return 'https://pos.fahrudina.my.id';
 };
 
 /**

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -111,7 +111,7 @@ export const LandingPage: React.FC = () => {
                 <span className="text-white font-bold text-base sm:text-lg">SL</span>
               </div>
               <div className="min-w-0">
-                <h1 className="text-base sm:text-xl font-bold text-gray-900 truncate">Smart Laundry POS</h1>
+                <span className="block text-base sm:text-xl font-bold text-gray-900 truncate">Smart Laundry POS</span>
                 <p className="text-xs text-gray-500 hidden sm:block">Sistem Kasir Laundry Profesional</p>
               </div>
             </div>
@@ -146,7 +146,7 @@ export const LandingPage: React.FC = () => {
               Aplikasi Web Progresif
             </Badge>
             <h1 className="text-4xl md:text-6xl font-bold text-gray-900 mb-6 leading-tight">
-              ✨ Solusi 
+              Aplikasi Kasir Laundry Modern
               <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-indigo-600">
                 {" "}Smart Laundry POS
               </span>


### PR DESCRIPTION
## Summary
Optimize SEO for the live site **https://pos.fahrudina.my.id**.

**Root problem:** the entire SEO surface (canonical, Open Graph, Twitter, JSON-LD, `robots.txt`, `sitemap.xml`) pointed at the old `smart-laundry-pos.vercel.app`. That sends conflicting canonical signals to search engines and breaks social link previews on the real domain.

## Changes
### Canonical & domain (the big fix)
- Added `<link rel="canonical" href="https://pos.fahrudina.my.id/">`.
- Pointed `og:url`, Twitter, JSON-LD `url`/`@id`, `robots.txt` sitemap, and all `sitemap.xml` locs at the live domain.
- Updated the stale WhatsApp receipt-URL fallback too.

### Social / Open Graph
- Made `og:image` / `twitter:image` **absolute URLs** (relative ones don't resolve for scrapers) + added `og:image:width/height/alt`.

### Structured data
- Expanded JSON-LD into a `@graph`: **WebSite + Organization + SoftwareApplication**, with `inLanguage`, logo, contactPoint, and proper publisher/creator references. (Validated: parses cleanly.)

### Crawlability for an SPA
- Added a `<noscript>` fallback with the key product copy, headings, and keywords, so non-JS crawlers and social scrapers get real content (the app is client-rendered).
- `robots.txt`: disallow all private app routes (`/home`, `/pos`, `/customers`, `/receipt/`, …), allow `/`, `/login`, `/install`.
- `sitemap.xml`: correct domain, added `/install`, refreshed `lastmod`.

### On-page (landing)
- Single keyword-rich `<h1>`: "Aplikasi Kasir Laundry Modern — Smart Laundry POS". Demoted the logo wordmark from a second `<h1>` to a `<span>` (was a duplicate H1).

## Verification
- [x] 0 remaining references to the old domain
- [x] JSON-LD parses (WebSite, Organization, SoftwareApplication)
- [x] `npx tsc --noEmit` clean, `npm run build` passes; `dist/index.html` emits the correct domain

## Post-merge (manual, recommended)
1. **Google Search Console** + **Bing Webmaster**: verify `pos.fahrudina.my.id`, submit the sitemap.
2. Add a dedicated **1200×630 `og-image.png`** (currently reusing the 512² favicon) for richer social cards, then point OG/Twitter image at it.
3. Consider **prerendering / SSG for the public pages** (`/`, `/login`, `/install`) — the biggest remaining SPA-SEO win, but a larger build change so kept out of this PR.
4. If the old `*.vercel.app` is still live, 301-redirect it to `pos.fahrudina.my.id` to consolidate link equity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added no-JavaScript fallback page to improve accessibility for users without JavaScript enabled

* **Improvements**
  * Migrated domain configuration across all social sharing metadata and search engine optimization settings
  * Updated sitemap and web crawler directives for the new domain
  * Refreshed landing page messaging and branding elements
  * Added new installation page route

<!-- end of auto-generated comment: release notes by coderabbit.ai -->