### PR TITLE
redesign(landing): rebuild landing page around the laundry claim ticket

### DIFF
--- a/src/pages/LandingPage.css
+++ b/src/pages/LandingPage.css
@@ -1,0 +1,300 @@
+/*
+  Design language for the public landing page only (scoped under .tk-page).
+  Signature idea: the page is built out of the laundry claim ticket — the
+  perforated duplicate stub every customer gets handed at the counter.
+  Perforation dividers, torn-edge stubs, ink-stamp marks and monospace
+  ticket numerals recur through every section instead of generic
+  gradient/glassmorphism panels. This intentionally does not touch the
+  app-wide --primary/--background tokens in src/index.css, which the
+  authenticated POS UI still relies on.
+*/
+
+.tk-page {
+  --tk-paper: #f5f0e4;
+  --tk-paper-soft: #efe6d2;
+  --tk-carbon: #e8b9bb;
+  --tk-carbon-deep: #c96a6f;
+  --tk-carbon-rgb: 201, 106, 111;
+  --tk-cross: #a8484d;
+  --tk-ink: #23324a;
+  --tk-ink-rgb: 35, 50, 74;
+  --tk-ink-soft: #4c5972;
+  --tk-graphite: #201c17;
+  --tk-graphite-soft: #5c5648;
+  --tk-line: #d8cbaa;
+  --tk-paid: #2e6b4c;
+  --tk-paid-rgb: 46, 107, 76;
+
+  --tk-font-mono: 'IBM Plex Mono', 'SFMono-Regular', ui-monospace, Menlo, monospace;
+  --tk-font-body: 'IBM Plex Sans', 'Inter', system-ui, sans-serif;
+
+  background: var(--tk-paper);
+  color: var(--tk-graphite);
+  font-family: var(--tk-font-body);
+  -webkit-font-smoothing: antialiased;
+}
+
+.tk-page,
+.tk-page input,
+.tk-page textarea {
+  font-family: var(--tk-font-body);
+}
+
+.tk-mono {
+  font-family: var(--tk-font-mono);
+}
+
+/* ---------- eyebrow / label chip ---------- */
+
+.tk-eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: var(--tk-font-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--tk-ink);
+  padding: 0.35rem 0.7rem;
+  border: 1px solid var(--tk-ink);
+  border-radius: 2px;
+}
+
+.tk-eyebrow::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--tk-carbon-deep);
+  flex-shrink: 0;
+}
+
+.tk-eyebrow--light {
+  color: var(--tk-paper);
+  border-color: rgba(245, 240, 228, 0.4);
+}
+
+/* ---------- perforation dividers ---------- */
+
+.tk-perforation {
+  height: 22px;
+  width: 100%;
+  background-color: var(--tk-line);
+  -webkit-mask-image: radial-gradient(circle 5px at 11px 11px, transparent 5px, black 5.5px);
+  mask-image: radial-gradient(circle 5px at 11px 11px, transparent 5px, black 5.5px);
+  -webkit-mask-size: 22px 22px;
+  mask-size: 22px 22px;
+  -webkit-mask-repeat: repeat-x;
+  mask-repeat: repeat-x;
+}
+
+.tk-perforation--ink {
+  background-color: var(--tk-ink);
+}
+
+/* ---------- ink stamp ---------- */
+
+.tk-stamp {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  font-family: var(--tk-font-mono);
+  font-weight: 700;
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 2px solid var(--tk-paid);
+  color: var(--tk-paid);
+  background: rgba(var(--tk-paid-rgb), 0.07);
+  border-radius: 5px;
+  padding: 0.3em 0.65em;
+  transform: rotate(-3deg);
+}
+
+/* ---------- ticket stub cards (features) ---------- */
+
+.tk-stub {
+  position: relative;
+  background: #fffdf8;
+  border: 1px solid var(--tk-line);
+  padding: 2rem 1.5rem 1.75rem;
+  clip-path: polygon(
+    0% 10px, 5% 0, 10% 10px, 15% 0, 20% 10px, 25% 0, 30% 10px, 35% 0,
+    40% 10px, 45% 0, 50% 10px, 55% 0, 60% 10px, 65% 0, 70% 10px, 75% 0,
+    80% 10px, 85% 0, 90% 10px, 95% 0, 100% 10px,
+    100% 100%, 0% 100%
+  );
+  filter: drop-shadow(0 10px 18px rgba(32, 28, 23, 0.1));
+  transition: transform 0.25s ease, filter 0.25s ease;
+}
+
+.tk-stub:hover {
+  transform: translateY(-5px) rotate(-0.5deg);
+  filter: drop-shadow(0 16px 26px rgba(32, 28, 23, 0.16));
+}
+
+.tk-stub__num {
+  position: absolute;
+  top: 0.9rem;
+  right: 1.1rem;
+  font-family: var(--tk-font-mono);
+  font-size: 0.75rem;
+  color: var(--tk-graphite-soft);
+  letter-spacing: 0.04em;
+}
+
+/* ---------- hero ticket ---------- */
+
+.tk-hero-ticket {
+  position: relative;
+  background: #fffdf8;
+  border: 1px solid var(--tk-line);
+  box-shadow: 0 24px 50px -20px rgba(32, 28, 23, 0.35);
+  transform: rotate(-1.1deg);
+}
+
+.tk-hero-barcode {
+  height: 34px;
+  background-image: repeating-linear-gradient(
+    90deg,
+    var(--tk-graphite) 0 2px,
+    transparent 2px 5px,
+    var(--tk-graphite) 5px 6px,
+    transparent 6px 9px,
+    var(--tk-graphite) 9px 12px,
+    transparent 12px 19px,
+    var(--tk-graphite) 19px 21px,
+    transparent 21px 26px
+  );
+  opacity: 0.85;
+}
+
+@keyframes tk-print-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10%) rotate(-3deg);
+    clip-path: inset(0 0 100% 0);
+  }
+  55% {
+    opacity: 1;
+    clip-path: inset(0 0 0% 0);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) rotate(-1.1deg);
+    clip-path: inset(0 0 0% 0);
+  }
+}
+
+.tk-hero-ticket {
+  animation: tk-print-in 0.9s cubic-bezier(0.2, 0.7, 0.15, 1) both;
+}
+
+/* ---------- ledger / comparison table ---------- */
+
+.tk-ledger {
+  background: #fffdf8;
+  border: 1px solid var(--tk-line);
+}
+
+.tk-ledger th,
+.tk-ledger td {
+  border-color: var(--tk-line);
+}
+
+.tk-ledger tbody tr:nth-child(even) {
+  background: var(--tk-paper-soft);
+}
+
+.tk-check {
+  font-family: var(--tk-font-mono);
+  font-weight: 700;
+  color: var(--tk-paid);
+}
+
+.tk-cross {
+  font-family: var(--tk-font-mono);
+  font-weight: 700;
+  color: var(--tk-cross);
+}
+
+.tk-partial {
+  font-family: var(--tk-font-mono);
+  font-weight: 600;
+  color: var(--tk-graphite-soft);
+}
+
+/* ---------- boarding-pass style install card ---------- */
+
+.tk-boarding {
+  position: relative;
+  background: var(--tk-ink);
+  color: var(--tk-paper);
+}
+
+.tk-boarding::before,
+.tk-boarding::after {
+  content: '';
+  position: absolute;
+  left: -14px;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--tk-paper);
+}
+
+.tk-boarding::before {
+  top: -14px;
+}
+
+.tk-boarding::after {
+  bottom: -14px;
+}
+
+/* ---------- ink band (emotional section + footer) ---------- */
+
+.tk-ink-band {
+  background: var(--tk-ink);
+  color: var(--tk-paper);
+}
+
+/* ---------- tear-off CTA ---------- */
+
+.tk-tear {
+  border-top: 3px dashed rgba(245, 240, 228, 0.35);
+  position: relative;
+}
+
+.tk-tear::before {
+  content: '';
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--tk-paper);
+}
+
+/* ---------- motion & accessibility ---------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .tk-hero-ticket {
+    animation: none;
+  }
+  .tk-stub,
+  .tk-stub:hover {
+    transition: none;
+  }
+}
+
+.tk-page :focus-visible {
+  outline: 2px solid var(--tk-ink);
+  outline-offset: 2px;
+}
+
+.tk-ink-band :focus-visible {
+  outline-color: var(--tk-paper);
+}

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,533 +1,574 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
-import { 
-  Smartphone, 
-  Cloud, 
-  Shield, 
-  Zap, 
-  Users, 
-  BarChart3, 
-  Clock, 
-  CreditCard,
-  Star,
-  CheckCircle,
-  ArrowRight,
-  Download,
-  Globe,
-  Wifi,
-  Monitor,
+import {
+  Zap,
   Receipt,
   MessageSquare,
+  BarChart3,
   Store,
   Gift,
   Megaphone,
-  TrendingUp,
-  Check,
-  X,
-  AlertCircle
+  Smartphone,
+  Monitor,
+  Globe,
+  Wifi,
+  Download,
+  ArrowRight,
+  ArrowUpRight,
 } from 'lucide-react';
 import { PWAInstallButton } from '@/components/ui/PWAInstallButton';
 import { WhatsAppFloatingButton } from '@/components/ui/WhatsAppFloatingButton';
+import './LandingPage.css';
+
+const FONT_LINK_ID = 'tk-landing-fonts';
+
+/** Loads the ticket-stub type pair only while the landing page is mounted,
+ * so authenticated app sessions never pay for this download. */
+const useLandingFonts = () => {
+  useEffect(() => {
+    if (document.getElementById(FONT_LINK_ID)) return;
+    const link = document.createElement('link');
+    link.id = FONT_LINK_ID;
+    link.rel = 'stylesheet';
+    link.href =
+      'https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600;700&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap';
+    document.head.appendChild(link);
+  }, []);
+};
+
+const features = [
+  {
+    serial: '0231',
+    icon: Zap,
+    title: 'Input Order Super Cepat',
+    description: 'Timbang, pilih layanan, cetak — antrian pagi tidak lagi menumpuk di meja kasir.',
+  },
+  {
+    serial: '0454',
+    icon: Receipt,
+    title: 'Struk & e-Struk Otomatis',
+    description: 'Setiap transaksi keluar dengan nota rapi, lengkap dengan berat dan rincian harga.',
+  },
+  {
+    serial: '0512',
+    icon: MessageSquare,
+    title: 'Notifikasi WhatsApp Real-time',
+    description: 'Pelanggan tahu persis kapan cucian siap diambil, tanpa mereka harus telepon dulu.',
+  },
+  {
+    serial: '0687',
+    icon: BarChart3,
+    title: 'Dashboard Omzet & Laporan Harian',
+    description: 'Uang masuk, kinerja outlet, dan jam sibuk terbaca dalam satu layar.',
+  },
+  {
+    serial: '0733',
+    icon: Store,
+    title: 'Multi-outlet & Multi-kasir',
+    description: 'Buka cabang kedua, ketiga, keempat — datanya tetap satu sistem, bukan satu buku per toko.',
+  },
+  {
+    serial: '0810',
+    icon: Gift,
+    title: 'Smart Point untuk Pelanggan Loyal',
+    description: 'Poin terkumpul otomatis tiap transaksi, jadi alasan pelanggan balik ke toko kamu lagi.',
+  },
+  {
+    serial: '0902',
+    icon: Megaphone,
+    title: 'Broadcast Promo ke Pelanggan',
+    description: 'Kirim info promo ke seluruh daftar pelanggan lewat WhatsApp, sekali klik.',
+  },
+];
+
+const benefits = [
+  'Dukungan manajemen multi-toko',
+  'Pelacakan pesanan real-time',
+  'Kalkulasi harga otomatis',
+  'Sistem notifikasi pelanggan',
+  'Manajemen inventori',
+  'Pelaporan keuangan',
+  'Tools manajemen staff',
+  'Dukungan mode offline',
+];
+
+const comparisonRows: {
+  feature: string;
+  smart: 'yes';
+  qasir: 'yes' | 'no' | 'partial';
+  pawoon: 'yes' | 'no' | 'partial';
+  majoo: 'yes' | 'no' | 'partial';
+  note?: { qasir?: string; pawoon?: string; majoo?: string };
+}[] = [
+  {
+    feature: 'Dioptimalkan untuk bisnis laundry',
+    smart: 'yes',
+    qasir: 'no',
+    pawoon: 'no',
+    majoo: 'no',
+    note: { qasir: 'POS umum', pawoon: 'POS umum', majoo: 'POS umum' },
+  },
+  { feature: 'Input laundry cepat (per kg / item)', smart: 'yes', qasir: 'no', pawoon: 'no', majoo: 'no' },
+  {
+    feature: 'Struk + e-struk laundry',
+    smart: 'yes',
+    qasir: 'partial',
+    pawoon: 'partial',
+    majoo: 'partial',
+    note: { qasir: 'Dasar', pawoon: 'Dasar', majoo: 'Dasar' },
+  },
+  {
+    feature: 'Loyalty khusus laundry (Smart Point)',
+    smart: 'yes',
+    qasir: 'no',
+    pawoon: 'no',
+    majoo: 'yes',
+    note: { majoo: 'Poin umum' },
+  },
+  { feature: 'Notifikasi WhatsApp otomatis', smart: 'yes', qasir: 'no', pawoon: 'no', majoo: 'no' },
+  {
+    feature: 'Broadcast promo pelanggan',
+    smart: 'yes',
+    qasir: 'partial',
+    pawoon: 'partial',
+    majoo: 'partial',
+    note: { qasir: 'Manual', pawoon: 'Manual', majoo: 'Terbatas' },
+  },
+  { feature: 'Multi-outlet laundry', smart: 'yes', qasir: 'partial', pawoon: 'yes', majoo: 'yes' },
+  { feature: 'Tracking status cucian', smart: 'yes', qasir: 'no', pawoon: 'no', majoo: 'no' },
+  { feature: 'Antrean & label laundry', smart: 'yes', qasir: 'no', pawoon: 'no', majoo: 'no' },
+  {
+    feature: 'Harga ramah UMKM',
+    smart: 'yes',
+    qasir: 'yes',
+    pawoon: 'no',
+    majoo: 'no',
+    note: { pawoon: 'Lebih mahal', majoo: 'Lebih mahal' },
+  },
+];
+
+const Mark: React.FC<{ value: 'yes' | 'no' | 'partial'; note?: string }> = ({ value, note }) => {
+  if (value === 'yes') return <span className="tk-check">✓</span>;
+  if (value === 'no')
+    return (
+      <span className="tk-cross">
+        ✕{note ? <span className="block text-[0.65rem] font-normal normal-case tk-mono text-[var(--tk-graphite-soft)]">{note}</span> : null}
+      </span>
+    );
+  return (
+    <span className="tk-partial">
+      ~{note ? <span className="block text-[0.65rem] font-normal normal-case tk-mono text-[var(--tk-graphite-soft)]">{note}</span> : null}
+    </span>
+  );
+};
 
 export const LandingPage: React.FC = () => {
   const navigate = useNavigate();
-
-  const features = [
-    {
-      icon: <Zap className="h-8 w-8" />,
-      emoji: "⚡",
-      title: "Input Order Super Cepat",
-      description: "Antrian lebih pendek, pelanggan lebih happy.",
-      gradient: "from-yellow-400 to-orange-500"
-    },
-    {
-      icon: <Receipt className="h-8 w-8" />,
-      emoji: "🧾",
-      title: "Cetak Struk / e-Struk Otomatis",
-      description: "Laundry kamu langsung terlihat profesional.",
-      gradient: "from-blue-400 to-cyan-500"
-    },
-    {
-      icon: <MessageSquare className="h-8 w-8" />,
-      emoji: "💬",
-      title: "Notifikasi WhatsApp Real-time",
-      description: "Pelanggan merasa diperhatikan → trust meningkat.",
-      gradient: "from-green-400 to-emerald-500"
-    },
-    {
-      icon: <BarChart3 className="h-8 w-8" />,
-      emoji: "📊",
-      title: "Dashboard Omzet & Laporan Harian",
-      description: "Monitoring uang masuk, outlet, dan karyawan.",
-      gradient: "from-purple-400 to-pink-500"
-    },
-    {
-      icon: <Store className="h-8 w-8" />,
-      emoji: "🏬",
-      title: "Support Multi-outlet & Multi-kasir",
-      description: "Cocok untuk bisnis yang mau scale.",
-      gradient: "from-indigo-400 to-blue-500"
-    },
-    {
-      icon: <Gift className="h-8 w-8" />,
-      emoji: "🎁",
-      title: "Smart Point untuk Pelanggan Loyal",
-      description: "Bikin mereka kembali, bukan ke kompetitor.",
-      gradient: "from-red-400 to-rose-500"
-    },
-    {
-      icon: <Megaphone className="h-8 w-8" />,
-      emoji: "📢",
-      title: "Broadcast Promo ke Pelanggan",
-      description: "Sekali klik → semua pelanggan tahu promo kamu.",
-      gradient: "from-amber-400 to-yellow-500"
-    }
-  ];
-
-  const benefits = [
-    "Dukungan manajemen multi-toko",
-    "Pelacakan pesanan real-time",
-    "Kalkulasi harga otomatis",
-    "Sistem notifikasi pelanggan",
-    "Manajemen inventori",
-    "Pelaporan keuangan",
-    "Tools manajemen staff",
-    "Dukungan mode offline"
-  ];
+  useLandingFonts();
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-indigo-50 pb-24 sm:pb-0">
+    <div className="tk-page min-h-screen pb-24 sm:pb-0">
       {/* SEO/OG meta tags live in index.html (React 18 does not hoist tags rendered here) */}
 
       {/* Header */}
-      <header className="bg-white/80 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-50">
+      <header className="sticky top-0 z-50 border-b border-[var(--tk-line)] bg-[rgba(245,240,228,0.95)] backdrop-blur-sm">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center h-16">
-            <div className="flex items-center min-w-0 flex-1">
-              <div className="w-8 h-8 sm:w-10 sm:h-10 bg-gradient-to-r from-blue-600 to-indigo-600 rounded-xl flex items-center justify-center mr-2 sm:mr-3 flex-shrink-0">
-                <span className="text-white font-bold text-base sm:text-lg">SL</span>
+            <div className="flex items-center min-w-0 flex-1 gap-2 sm:gap-3">
+              <div className="w-9 h-9 flex-shrink-0 border-2 border-[var(--tk-ink)] rounded-sm flex items-center justify-center tk-mono font-bold text-[var(--tk-ink)] text-sm">
+                SL
               </div>
               <div className="min-w-0">
-                <span className="block text-base sm:text-xl font-bold text-gray-900 truncate">Smart Laundry POS</span>
-                <p className="text-xs text-gray-500 hidden sm:block">Sistem Kasir Laundry Profesional</p>
+                <span className="block text-base sm:text-lg font-bold text-[var(--tk-graphite)] truncate">
+                  Smart Laundry POS
+                </span>
+                <p className="text-[0.7rem] tk-mono tracking-wide text-[var(--tk-graphite-soft)] hidden sm:block">
+                  SISTEM KASIR LAUNDRY
+                </p>
               </div>
             </div>
-            <div className="flex items-center gap-2 sm:gap-4 flex-shrink-0">
-              <PWAInstallButton />
-              <Button 
-                variant="outline"
+            <div className="flex items-center gap-2 sm:gap-3 flex-shrink-0">
+              <PWAInstallButton className="!bg-transparent !border-[var(--tk-line)] !text-[var(--tk-ink)] hover:!bg-[var(--tk-paper-soft)]" />
+              <button
                 onClick={() => navigate('/install')}
-                className="hidden sm:flex"
+                className="hidden sm:inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border border-[var(--tk-line)] rounded-sm text-[var(--tk-ink-soft)] hover:bg-[var(--tk-paper-soft)] transition-colors"
               >
-                <Download className="h-4 w-4 mr-2" />
+                <Download className="h-4 w-4" />
                 Install Manual
-              </Button>
-              <Button 
+              </button>
+              <button
                 onClick={() => navigate('/login')}
-                className="bg-blue-600 hover:bg-blue-700 text-white text-sm sm:text-base px-3 sm:px-4"
+                className="inline-flex items-center px-4 sm:px-5 py-2 text-sm sm:text-base font-semibold rounded-sm bg-[var(--tk-ink)] text-[var(--tk-paper)] hover:bg-[var(--tk-graphite)] transition-colors"
               >
                 Masuk
-              </Button>
+              </button>
             </div>
           </div>
         </div>
       </header>
 
-      {/* Hero Section */}
-      <section className="relative overflow-hidden py-20 lg:py-32">
-        <div className="absolute inset-0 bg-gradient-to-r from-blue-600/10 to-indigo-600/10"></div>
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center">
-            <Badge variant="secondary" className="mb-6 bg-blue-100 text-blue-800">
-              <Smartphone className="h-3 w-3 mr-1" />
-              Aplikasi Web Progresif
-            </Badge>
-            <h1 className="text-4xl md:text-6xl font-bold text-gray-900 mb-6 leading-tight">
-              Aplikasi Kasir Laundry Modern
-              <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-600 to-indigo-600">
-                {" "}Smart Laundry POS
-              </span>
-            </h1>
-            <p className="text-xl md:text-2xl text-gray-700 mb-4 max-w-3xl mx-auto font-medium">
-              Jalankan usaha laundry dengan cara yang lebih modern, cepat, dan menguntungkan.
-            </p>
-            <p className="text-lg text-gray-600 mb-8 max-w-3xl mx-auto">
-              Tanpa ribet. Tanpa pusing catatan kertas. Semua otomatis.
-            </p>
-            <p className="text-lg text-blue-600 mb-8 max-w-3xl mx-auto font-semibold italic">
-              Karena bisnis laundry kamu layak terlihat profesional — dan pelangganmu layak mendapat pelayanan premium.
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
-              <Button 
-                size="lg" 
-                onClick={() => navigate('/login?tab=signup')}
-                className="w-full sm:w-auto bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white px-6 sm:px-10 py-5 sm:py-6 text-lg sm:text-xl font-bold shadow-2xl hover:shadow-3xl transition-all duration-300 transform hover:scale-105"
-              >
-                <span className="truncate">👉 Coba Smart Laundry POS Sekarang!</span>
-                <ArrowRight className="ml-2 h-5 w-5 sm:h-6 sm:w-6 flex-shrink-0" />
-              </Button>
+      {/* Hero */}
+      <section className="relative pt-14 pb-20 sm:pt-20 sm:pb-28 px-4 sm:px-6 lg:px-8 overflow-hidden">
+        <div className="max-w-5xl mx-auto">
+          <div className="tk-hero-ticket rounded-sm overflow-hidden">
+            <div className="tk-hero-barcode" />
+            <div className="flex items-center justify-between px-6 sm:px-10 py-3 border-b border-dashed border-[var(--tk-line)] tk-mono text-xs sm:text-sm text-[var(--tk-graphite-soft)] tracking-widest uppercase">
+              <span>Nota Laundry — Aplikasi Kasir</span>
+              <span>No. 00142</span>
             </div>
-            <div className="mt-6 text-center space-y-2">
-              <p className="text-lg text-green-600 font-semibold">🎁 Mulai gratis. Tidak perlu kartu kredit.</p>
-              <p className="text-md text-gray-600">Set-up dalam 5 menit. Rasakan bedanya hari ini.</p>
+
+            <div className="px-6 sm:px-10 py-10 sm:py-14">
+              <span className="tk-eyebrow mb-6">Untuk Laundry Kiloan &amp; Satuan</span>
+
+              <h1 className="text-[2.1rem] leading-[1.12] sm:text-5xl sm:leading-[1.1] lg:text-6xl font-bold text-[var(--tk-graphite)] mb-6 max-w-3xl">
+                Kasir laundry yang jalan secepat antrian pagi.
+              </h1>
+              <p className="text-lg sm:text-xl text-[var(--tk-ink-soft)] mb-3 max-w-2xl">
+                Smart Laundry POS mencatat berat, harga, dan status cucian dari input sampai diambil
+                pelanggan — bukan aplikasi kasir umum yang dipaksa-paskan untuk laundry.
+              </p>
+              <p className="text-base sm:text-lg text-[var(--tk-graphite-soft)] mb-8 max-w-2xl">
+                Tanpa nota tulis tangan yang gampang hilang. Tanpa hitung manual di kalkulator.
+              </p>
+
+              <div className="flex flex-wrap gap-x-8 gap-y-3 mb-9 tk-mono text-sm">
+                <div>
+                  <div className="text-[var(--tk-graphite-soft)] text-xs tracking-widest uppercase">Berat</div>
+                  <div className="font-bold text-[var(--tk-graphite)] text-lg">2.4 KG</div>
+                </div>
+                <div>
+                  <div className="text-[var(--tk-graphite-soft)] text-xs tracking-widest uppercase">Total</div>
+                  <div className="font-bold text-[var(--tk-graphite)] text-lg">Rp 24.000</div>
+                </div>
+                <div className="flex items-end">
+                  <span className="tk-stamp">Siap Diambil</span>
+                </div>
+              </div>
+
+              <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
+                <button
+                  onClick={() => navigate('/login?tab=signup')}
+                  className="inline-flex items-center justify-center gap-2 px-7 py-4 text-base sm:text-lg font-bold rounded-sm bg-[var(--tk-ink)] text-[var(--tk-paper)] hover:bg-[var(--tk-graphite)] transition-colors"
+                >
+                  Ambil Tiket Gratis
+                  <ArrowRight className="h-5 w-5" />
+                </button>
+                <a
+                  href="#fitur"
+                  className="inline-flex items-center justify-center gap-2 px-7 py-4 text-base sm:text-lg font-semibold rounded-sm border border-[var(--tk-ink)] text-[var(--tk-ink)] hover:bg-[rgba(35,50,74,0.05)] transition-colors"
+                >
+                  Lihat Cara Kerja
+                </a>
+              </div>
             </div>
           </div>
+
+          <p className="text-center mt-6 text-sm sm:text-base text-[var(--tk-graphite-soft)] tk-mono">
+            GRATIS DIPAKAI &middot; TANPA KARTU KREDIT &middot; SIAP PAKAI DALAM 5 MENIT
+          </p>
         </div>
       </section>
 
-      {/* App Screenshots Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <Badge variant="secondary" className="mb-6 bg-indigo-100 text-indigo-800">
-              <Monitor className="h-3 w-3 mr-1" />
-              Tampilan Aplikasi
-            </Badge>
-            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
-              Lihat Smart Laundry POS dalam Aksi
+      <div className="tk-perforation" />
+
+      {/* App Screenshots */}
+      <section className="py-16 sm:py-24 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto">
+          <div className="text-center mb-14">
+            <span className="tk-eyebrow mb-5">Tampilan Asli</span>
+            <h2 className="text-3xl md:text-4xl font-bold text-[var(--tk-graphite)] mb-4">
+              Dari meja kasir ke genggaman tangan
             </h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              Antarmuka intuitif yang dirancang untuk kemudahan penggunaan di semua perangkat
+            <p className="text-lg text-[var(--tk-ink-soft)] max-w-2xl mx-auto">
+              Antarmuka yang sama enaknya dipakai di HP kasir maupun layar besar di meja depan toko.
             </p>
           </div>
 
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 items-start">
             {/* Mobile View */}
-            <div className="relative">
-              <div className="absolute -inset-4 bg-gradient-to-r from-blue-400 to-indigo-400 rounded-3xl blur-2xl opacity-20"></div>
-              <div className="relative bg-white rounded-3xl shadow-2xl p-8">
-                <div className="flex items-center justify-between mb-6">
-                  <div className="flex items-center gap-2">
-                    <Smartphone className="h-6 w-6 text-blue-600" />
-                    <h3 className="text-xl font-bold text-gray-900">Tampilan Mobile</h3>
-                  </div>
-                  <Badge className="bg-blue-600">Responsif</Badge>
+            <div className="tk-stub rounded-sm">
+              <div className="tk-stub__num">No. 0021</div>
+              <div className="flex items-center gap-2 mb-5">
+                <Smartphone className="h-5 w-5 text-[var(--tk-ink)]" />
+                <h3 className="text-lg font-bold text-[var(--tk-graphite)]">Tampilan Mobile</h3>
+              </div>
+              <div className="relative bg-[var(--tk-paper-soft)] overflow-hidden border-8 border-[var(--tk-graphite)] rounded-2xl aspect-[9/19] max-h-[420px] mx-auto">
+                <img
+                  src="/screenshots/mobile-1.png"
+                  alt="Smart Laundry POS Mobile View"
+                  className="w-full h-full object-cover"
+                  onError={(e) => {
+                    const target = e.target as HTMLImageElement;
+                    target.style.display = 'none';
+                    const parent = target.parentElement;
+                    if (parent) {
+                      parent.innerHTML = `
+                        <div class="flex flex-col items-center justify-center h-full text-[var(--tk-graphite-soft)] p-8">
+                          <p class="text-center text-base font-medium">Aplikasi POS Mobile</p>
+                          <p class="text-center text-sm mt-2">Kelola pesanan dari smartphone Anda</p>
+                        </div>
+                      `;
+                    }
+                  }}
+                />
+              </div>
+              <div className="mt-6 grid grid-cols-3 gap-3 text-center tk-mono">
+                <div>
+                  <Zap className="h-4 w-4 mx-auto mb-1 text-[var(--tk-ink)]" />
+                  <div className="text-xs text-[var(--tk-graphite-soft)]">Cepat</div>
                 </div>
-                <div className="relative bg-gradient-to-br from-blue-50 to-indigo-50 rounded-2xl overflow-hidden border-8 border-gray-800 shadow-xl aspect-[9/19]">
-                  <img 
-                    src="/screenshots/mobile-1.png" 
-                    alt="Smart Laundry POS Mobile View"
-                    className="w-full h-full object-cover"
-                    onError={(e) => {
-                      // Fallback to a placeholder if image doesn't load
-                      const target = e.target as HTMLImageElement;
-                      target.style.display = 'none';
-                      const parent = target.parentElement;
-                      if (parent) {
-                        parent.innerHTML = `
-                          <div class="flex flex-col items-center justify-center h-full text-gray-500 p-8">
-                            <svg class="w-24 h-24 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"></path>
-                            </svg>
-                            <p class="text-center text-lg font-medium">Aplikasi POS Mobile</p>
-                            <p class="text-center text-sm mt-2">Kelola pesanan dari smartphone Anda</p>
-                          </div>
-                        `;
-                      }
-                    }}
-                  />
+                <div>
+                  <Smartphone className="h-4 w-4 mx-auto mb-1 text-[var(--tk-ink)]" />
+                  <div className="text-xs text-[var(--tk-graphite-soft)]">Ramah Sentuh</div>
                 </div>
-                <div className="mt-6 grid grid-cols-3 gap-4 text-center">
-                  <div>
-                    <div className="text-2xl font-bold text-blue-600">⚡</div>
-                    <div className="text-sm text-gray-600 mt-1">Super Cepat</div>
-                  </div>
-                  <div>
-                    <div className="text-2xl font-bold text-green-600">📱</div>
-                    <div className="text-sm text-gray-600 mt-1">Touch Friendly</div>
-                  </div>
-                  <div>
-                    <div className="text-2xl font-bold text-indigo-600">💾</div>
-                    <div className="text-sm text-gray-600 mt-1">Offline Mode</div>
-                  </div>
+                <div>
+                  <Wifi className="h-4 w-4 mx-auto mb-1 text-[var(--tk-ink)]" />
+                  <div className="text-xs text-[var(--tk-graphite-soft)]">Mode Offline</div>
                 </div>
               </div>
             </div>
 
             {/* Desktop View */}
-            <div className="relative">
-              <div className="absolute -inset-4 bg-gradient-to-r from-indigo-400 to-purple-400 rounded-3xl blur-2xl opacity-20"></div>
-              <div className="relative bg-white rounded-3xl shadow-2xl p-8">
-                <div className="flex items-center justify-between mb-6">
-                  <div className="flex items-center gap-2">
-                    <Monitor className="h-6 w-6 text-indigo-600" />
-                    <h3 className="text-xl font-bold text-gray-900">Tampilan Desktop</h3>
-                  </div>
-                  <Badge className="bg-indigo-600">Optimal</Badge>
+            <div className="tk-stub rounded-sm">
+              <div className="tk-stub__num">No. 0022</div>
+              <div className="flex items-center gap-2 mb-5">
+                <Monitor className="h-5 w-5 text-[var(--tk-ink)]" />
+                <h3 className="text-lg font-bold text-[var(--tk-graphite)]">Tampilan Desktop</h3>
+              </div>
+              <div className="relative bg-[var(--tk-paper-soft)] overflow-hidden border-4 border-[var(--tk-line)] rounded-xl aspect-video">
+                <img
+                  src="/favicon-512.png"
+                  alt="Smart Laundry POS Desktop View"
+                  className="w-full h-full object-contain p-12"
+                  onError={(e) => {
+                    const target = e.target as HTMLImageElement;
+                    target.style.display = 'none';
+                    const parent = target.parentElement;
+                    if (parent) {
+                      parent.innerHTML = `
+                        <div class="flex flex-col items-center justify-center h-full text-[var(--tk-graphite-soft)] p-8">
+                          <p class="text-center text-lg font-medium">Dashboard Desktop</p>
+                          <p class="text-center text-sm mt-2">Kelola bisnis dengan tampilan penuh</p>
+                        </div>
+                      `;
+                    }
+                  }}
+                />
+              </div>
+              <div className="mt-6 grid grid-cols-3 gap-3 text-center tk-mono">
+                <div>
+                  <BarChart3 className="h-4 w-4 mx-auto mb-1 text-[var(--tk-ink)]" />
+                  <div className="text-xs text-[var(--tk-graphite-soft)]">Dashboard</div>
                 </div>
-                <div className="relative bg-gradient-to-br from-indigo-50 to-purple-50 rounded-2xl overflow-hidden border-4 border-gray-300 shadow-xl aspect-video">
-                  <img 
-                    src="/favicon-512.png" 
-                    alt="Smart Laundry POS Desktop View"
-                    className="w-full h-full object-contain p-12"
-                    onError={(e) => {
-                      // Fallback to a placeholder if image doesn't load
-                      const target = e.target as HTMLImageElement;
-                      target.style.display = 'none';
-                      const parent = target.parentElement;
-                      if (parent) {
-                        parent.innerHTML = `
-                          <div class="flex flex-col items-center justify-center h-full text-gray-500 p-8">
-                            <svg class="w-32 h-32 mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
-                            </svg>
-                            <p class="text-center text-xl font-medium">Dashboard Desktop</p>
-                            <p class="text-center text-sm mt-2">Kelola bisnis dengan tampilan penuh</p>
-                          </div>
-                        `;
-                      }
-                    }}
-                  />
+                <div>
+                  <Zap className="h-4 w-4 mx-auto mb-1 text-[var(--tk-ink)]" />
+                  <div className="text-xs text-[var(--tk-graphite-soft)]">Pintasan Keyboard</div>
                 </div>
-                <div className="mt-6 grid grid-cols-3 gap-4 text-center">
-                  <div>
-                    <div className="text-2xl font-bold text-blue-600">📊</div>
-                    <div className="text-sm text-gray-600 mt-1">Dashboard</div>
-                  </div>
-                  <div>
-                    <div className="text-2xl font-bold text-green-600">⌨️</div>
-                    <div className="text-sm text-gray-600 mt-1">Keyboard Nav</div>
-                  </div>
-                  <div>
-                    <div className="text-2xl font-bold text-indigo-600">🖨️</div>
-                    <div className="text-sm text-gray-600 mt-1">Print Ready</div>
-                  </div>
+                <div>
+                  <Receipt className="h-4 w-4 mx-auto mb-1 text-[var(--tk-ink)]" />
+                  <div className="text-xs text-[var(--tk-graphite-soft)]">Siap Cetak</div>
                 </div>
               </div>
             </div>
           </div>
 
-          <div className="mt-16 text-center">
-            <p className="text-lg text-gray-600 mb-6">
+          <div className="mt-14 text-center">
+            <p className="text-base text-[var(--tk-ink-soft)] mb-5">
               Berfungsi sempurna di smartphone, tablet, dan komputer desktop
             </p>
-            <div className="flex flex-wrap justify-center gap-4">
-              <Badge variant="secondary" className="px-4 py-2">
-                <Smartphone className="h-4 w-4 mr-2" />
-                iOS & Android
-              </Badge>
-              <Badge variant="secondary" className="px-4 py-2">
-                <Monitor className="h-4 w-4 mr-2" />
-                Windows & Mac
-              </Badge>
-              <Badge variant="secondary" className="px-4 py-2">
-                <Globe className="h-4 w-4 mr-2" />
-                Chrome, Safari, Firefox
-              </Badge>
+            <div className="flex flex-wrap justify-center items-center gap-x-6 gap-y-2 tk-mono text-sm text-[var(--tk-graphite-soft)] uppercase tracking-wide">
+              <span>iOS &amp; Android</span>
+              <span aria-hidden="true" className="text-[var(--tk-line)]">/</span>
+              <span>Windows &amp; Mac</span>
+              <span aria-hidden="true" className="text-[var(--tk-line)]">/</span>
+              <span>Chrome · Safari · Firefox</span>
             </div>
           </div>
         </div>
       </section>
 
-      {/* Features Section */}
-      <section className="py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <Badge variant="secondary" className="mb-6 bg-gradient-to-r from-blue-100 to-indigo-100 text-blue-800 text-base px-4 py-2">
-              <Star className="h-4 w-4 mr-2" />
-              Fitur Unggulan
-            </Badge>
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              💡 Apa yang akan Kamu Dapatkan?
+      <div className="tk-perforation" />
+
+      {/* Features */}
+      <section id="fitur" className="py-16 sm:py-24 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto">
+          <div className="text-center mb-14">
+            <span className="tk-eyebrow mb-5">Isi Tiketnya</span>
+            <h2 className="text-3xl md:text-4xl font-bold text-[var(--tk-graphite)] mb-4">
+              Apa yang kamu dapat dari setiap transaksi
             </h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto">
-              Fitur-fitur canggih yang dirancang khusus untuk bisnis laundry modern
+            <p className="text-lg text-[var(--tk-ink-soft)] max-w-2xl mx-auto">
+              Tujuh hal yang biasanya hilang di antara buku catatan dan grup WhatsApp toko.
             </p>
-          </div>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature, index) => (
-              <Card key={index} className="border-2 border-transparent hover:border-blue-300 shadow-lg hover:shadow-2xl transition-all duration-300 transform hover:-translate-y-2 bg-gradient-to-br from-white to-gray-50">
-                <CardHeader>
-                  <div className={`w-16 h-16 bg-gradient-to-r ${feature.gradient} rounded-2xl flex items-center justify-center text-white mb-4 shadow-lg transform transition-transform hover:scale-110 hover:rotate-3`}>
-                    <span className="text-3xl">{feature.emoji}</span>
-                  </div>
-                  <CardTitle className="text-xl md:text-2xl font-bold text-gray-900">{feature.title}</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription className="text-gray-600 text-base">
-                    {feature.description}
-                  </CardDescription>
-                </CardContent>
-              </Card>
-            ))}
           </div>
 
-          <div className="mt-16 text-center bg-gradient-to-r from-blue-50 to-indigo-50 rounded-3xl p-8 border-2 border-blue-200">
-            <p className="text-2xl font-bold text-gray-900 mb-2">
-              "Bukan sekadar aplikasi — ini mesin pertumbuhan untuk bisnis laundry kamu."
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 sm:gap-10">
+            {features.map((feature) => {
+              const Icon = feature.icon;
+              return (
+                <div key={feature.serial} className="tk-stub rounded-sm">
+                  <div className="tk-stub__num">No. {feature.serial}</div>
+                  <div className="w-12 h-12 rounded-full border-2 border-[var(--tk-ink)] flex items-center justify-center mb-5 text-[var(--tk-ink)]">
+                    <Icon className="h-5 w-5" />
+                  </div>
+                  <h3 className="text-lg font-bold text-[var(--tk-graphite)] mb-2">{feature.title}</h3>
+                  <p className="text-[var(--tk-ink-soft)]">{feature.description}</p>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="mt-16 tk-ink-band rounded-sm p-8 sm:p-10 text-center">
+            <p className="text-xl sm:text-2xl font-bold mb-1">
+              &ldquo;Bukan sekadar aplikasi kasir — ini sistem pencatatan laundry dari ambil sampai bayar.&rdquo;
             </p>
-            <p className="text-lg text-gray-600">💪 Siap naik kelas?</p>
           </div>
         </div>
       </section>
 
-      {/* Comparison Table Section */}
-      <section className="py-20 bg-gradient-to-br from-gray-50 to-blue-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <Badge variant="secondary" className="mb-6 bg-yellow-100 text-yellow-800 text-base px-4 py-2">
-              <TrendingUp className="h-4 w-4 mr-2" />
-              Perbandingan Kompetitor
-            </Badge>
-            <h2 className="text-3xl md:text-5xl font-bold text-gray-900 mb-6">
-              🥊 Smart Laundry POS vs Qasir, Pawoon, Majoo
+      <div className="tk-perforation" />
+
+      {/* Comparison ledger */}
+      <section className="py-16 sm:py-24 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto">
+          <div className="text-center mb-10">
+            <span className="tk-eyebrow mb-5">Dibanding Aplikasi Kasir Umum</span>
+            <h2 className="text-3xl md:text-4xl font-bold text-[var(--tk-graphite)] mb-4">
+              Kenapa bukan aplikasi kasir biasa?
             </h2>
-            <p className="text-xl text-gray-600 max-w-3xl mx-auto mb-4">
-              Lihat mengapa Smart Laundry POS adalah pilihan terbaik untuk bisnis laundry
+            <p className="text-lg text-[var(--tk-ink-soft)] max-w-2xl mx-auto mb-2">
+              Perbandingan jujur dengan Qasir, Pawoon, dan Majoo — tiga aplikasi kasir umum yang paling
+              sering dipakai UMKM Indonesia.
             </p>
-            <p className="text-sm text-gray-500 md:hidden">
-              💡 Geser tabel ke kiri/kanan untuk melihat lebih banyak
+            <p className="text-sm text-[var(--tk-graphite-soft)] md:hidden tk-mono">
+              Geser tabel untuk melihat lebih banyak &rarr;
             </p>
           </div>
 
-          <div className="overflow-x-auto bg-white rounded-2xl shadow-2xl sm:rounded-2xl -mx-4 sm:mx-0 px-4 sm:px-0">
+          <div className="tk-ledger overflow-x-auto rounded-sm -mx-4 sm:mx-0">
             <div className="min-w-[640px] sm:min-w-0">
-            <table className="w-full text-left border-collapse">
-              <thead>
-                <tr className="bg-gradient-to-r from-blue-600 to-indigo-600 text-white">
-                  <th className="px-3 sm:px-6 py-3 sm:py-4 text-sm sm:text-lg font-bold border-r border-blue-500">Fitur</th>
-                  <th className="px-3 sm:px-6 py-3 sm:py-4 text-sm sm:text-lg font-bold text-center border-r border-blue-500 bg-blue-700">
-                    <div className="flex items-center justify-center gap-1 sm:gap-2">
-                      <Star className="h-4 w-4 sm:h-5 sm:w-5 text-yellow-300 flex-shrink-0" />
-                      <span className="whitespace-nowrap">Smart Laundry POS</span>
-                    </div>
-                  </th>
-                  <th className="px-3 sm:px-6 py-3 sm:py-4 text-sm sm:text-lg font-bold text-center border-r border-blue-500">Qasir</th>
-                  <th className="px-3 sm:px-6 py-3 sm:py-4 text-sm sm:text-lg font-bold text-center border-r border-blue-500">Pawoon</th>
-                  <th className="px-3 sm:px-6 py-3 sm:py-4 text-sm sm:text-lg font-bold text-center">Majoo</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-200">
-                {[
-                  { feature: "Dioptimalkan untuk bisnis laundry", smart: "✅", qasir: "❌ POS umum", pawoon: "❌ POS umum", majoo: "❌ POS umum" },
-                  { feature: "Input laundry cepat (by kg/item)", smart: "✅", qasir: "❌", pawoon: "❌", majoo: "❌" },
-                  { feature: "Struk + e-Struk laundry", smart: "✅", qasir: "⚠️ Basic", pawoon: "⚠️ Basic", majoo: "⚠️ Basic" },
-                  { feature: "Loyalty khusus laundry (Smart Point)", smart: "✅", qasir: "❌", pawoon: "❌", majoo: "✅ (general)" },
-                  { feature: "Notifikasi WA otomatis", smart: "✅", qasir: "❌", pawoon: "❌", majoo: "❌" },
-                  { feature: "Broadcast promo pelanggan", smart: "✅", qasir: "⚠️ Manual", pawoon: "⚠️ Manual", majoo: "⚠️ Terbatas" },
-                  { feature: "Multi-outlet laundry", smart: "✅", qasir: "⚠️", pawoon: "✅", majoo: "✅" },
-                  { feature: "Tracking status cucian", smart: "✅", qasir: "❌", pawoon: "❌", majoo: "❌" },
-                  { feature: "Antrean & label laundry", smart: "✅", qasir: "❌", pawoon: "❌", majoo: "❌" },
-                  { feature: "Harga untuk UMKM", smart: "✅ Ramah UMKM", qasir: "✅", pawoon: "❌ Lebih mahal", majoo: "❌ Lebih mahal" },
-                ].map((row, index) => (
-                  <tr key={index} className={index % 2 === 0 ? "bg-gray-50" : "bg-white"}>
-                    <td className="px-3 sm:px-6 py-3 sm:py-4 text-xs sm:text-base font-medium text-gray-900 border-r border-gray-200">{row.feature}</td>
-                    <td className="px-3 sm:px-6 py-3 sm:py-4 text-xs sm:text-base text-center font-bold bg-blue-50 border-r border-gray-200">{row.smart}</td>
-                    <td className="px-3 sm:px-6 py-3 sm:py-4 text-xs sm:text-base text-center border-r border-gray-200">{row.qasir}</td>
-                    <td className="px-3 sm:px-6 py-3 sm:py-4 text-xs sm:text-base text-center border-r border-gray-200">{row.pawoon}</td>
-                    <td className="px-3 sm:px-6 py-3 sm:py-4 text-xs sm:text-base text-center">{row.majoo}</td>
+              <table className="w-full text-left border-collapse">
+                <thead>
+                  <tr className="tk-ink-band tk-mono text-xs sm:text-sm uppercase tracking-wide">
+                    <th className="px-4 sm:px-6 py-4 font-semibold">Fitur</th>
+                    <th className="px-4 sm:px-6 py-4 font-semibold text-center">Smart Laundry POS</th>
+                    <th className="px-4 sm:px-6 py-4 font-semibold text-center">Qasir</th>
+                    <th className="px-4 sm:px-6 py-4 font-semibold text-center">Pawoon</th>
+                    <th className="px-4 sm:px-6 py-4 font-semibold text-center">Majoo</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {comparisonRows.map((row) => (
+                    <tr key={row.feature} className="border-b border-[var(--tk-line)] last:border-0">
+                      <td className="px-4 sm:px-6 py-4 text-sm sm:text-base font-medium text-[var(--tk-graphite)] border-r border-[var(--tk-line)]">
+                        {row.feature}
+                      </td>
+                      <td className="px-4 sm:px-6 py-4 text-center border-r border-[var(--tk-line)] bg-[rgba(46,107,76,0.05)]">
+                        <Mark value={row.smart} />
+                      </td>
+                      <td className="px-4 sm:px-6 py-4 text-center border-r border-[var(--tk-line)]">
+                        <Mark value={row.qasir} note={row.note?.qasir} />
+                      </td>
+                      <td className="px-4 sm:px-6 py-4 text-center border-r border-[var(--tk-line)]">
+                        <Mark value={row.pawoon} note={row.note?.pawoon} />
+                      </td>
+                      <td className="px-4 sm:px-6 py-4 text-center">
+                        <Mark value={row.majoo} note={row.note?.majoo} />
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
             </div>
           </div>
 
           <div className="mt-8 grid grid-cols-1 md:grid-cols-2 gap-6">
-            <div className="bg-red-50 border-2 border-red-200 rounded-xl p-6">
-              <div className="flex items-start gap-3">
-                <AlertCircle className="h-6 w-6 text-red-600 flex-shrink-0 mt-1" />
-                <div>
-                  <p className="text-lg font-bold text-red-900 mb-2">⚠️ POS umum tidak mengerti alur laundry.</p>
-                  <p className="text-red-700">Aplikasi POS umum tidak dirancang untuk kebutuhan spesifik bisnis laundry Anda.</p>
-                </div>
-              </div>
+            <div className="bg-[#fffdf8] border border-[var(--tk-line)] border-l-4 border-l-[var(--tk-carbon-deep)] rounded-sm p-6">
+              <p className="font-bold text-[var(--tk-graphite)] mb-2">Aplikasi kasir umum tidak mengerti alur laundry.</p>
+              <p className="text-[var(--tk-ink-soft)]">
+                Dibuat untuk toko kelontong atau resto, lalu dipaksakan untuk mencatat berat, layanan, dan status cucian.
+              </p>
             </div>
-            <div className="bg-green-50 border-2 border-green-200 rounded-xl p-6">
-              <div className="flex items-start gap-3">
-                <CheckCircle className="h-6 w-6 text-green-600 flex-shrink-0 mt-1" />
-                <div>
-                  <p className="text-lg font-bold text-green-900 mb-2">✅ Smart Laundry POS dibangun khusus untuk ekosistem laundry.</p>
-                  <p className="text-green-700">Setiap fitur dirancang dengan memahami workflow dan kebutuhan bisnis laundry.</p>
-                </div>
-              </div>
+            <div className="bg-[#fffdf8] border border-[var(--tk-line)] border-l-4 border-l-[var(--tk-paid)] rounded-sm p-6">
+              <p className="font-bold text-[var(--tk-graphite)] mb-2">Smart Laundry POS dibangun untuk ekosistem laundry.</p>
+              <p className="text-[var(--tk-ink-soft)]">
+                Setiap fitur mengikuti alur kerja nyata: timbang, catat, notifikasi, ambil, bayar.
+              </p>
             </div>
           </div>
         </div>
       </section>
 
-      {/* Emotional Hook Section */}
-      <section className="py-20 bg-gradient-to-r from-indigo-600 via-blue-600 to-cyan-600">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl md:text-4xl font-bold text-white mb-8 leading-tight">
-            🎯 Kamu sudah kerja keras bangun usaha laundry
+      {/* Emotional hook — ink band */}
+      <section className="tk-ink-band py-20 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-3xl mx-auto text-center">
+          <span className="tk-eyebrow tk-eyebrow--light mb-8">Sebelum Kamu Lanjut</span>
+          <h2 className="text-3xl md:text-4xl font-bold mb-8 leading-tight">
+            Kamu sudah kerja keras bangun usaha laundry ini.
           </h2>
-          <div className="space-y-4 text-xl text-blue-100 mb-8">
-            <p>✓ Sudah keluar modal beli mesin.</p>
-            <p>✓ Sudah latih pegawai.</p>
-            <p className="text-2xl font-bold text-yellow-300 mt-6">Tinggal satu langkah lagi:</p>
-            <p className="text-2xl font-bold text-white">Sistem yang bikin bisnismu rapi, dipercaya pelanggan, dan siap scale.</p>
+          <div className="space-y-3 text-lg sm:text-xl mb-10 opacity-90">
+            <p>Sudah keluar modal beli mesin cuci dan setrika.</p>
+            <p>Sudah latih pegawai supaya cucian rapi dan tepat waktu.</p>
           </div>
-          <div className="bg-white/10 backdrop-blur-sm border-2 border-white/30 rounded-2xl p-8 mb-8">
-            <p className="text-2xl md:text-3xl font-bold text-white mb-4">
-              Jangan biarkan catatan manual menahan pertumbuhan bisnismu.
+          <div className="border-t border-b border-dashed border-white/25 py-8 mb-10">
+            <p className="text-xl sm:text-2xl font-bold mb-3">
+              Tinggal satu hal yang belum rapi: catatannya.
             </p>
-            <p className="text-3xl font-bold text-yellow-300">
-              Saatnya naik kelas! 💪
+            <p className="text-lg text-[var(--tk-carbon)]">
+              Jangan biarkan nota tulis tangan menahan bisnis yang sudah kamu bangun susah payah.
             </p>
           </div>
-          <Button 
-            size="lg" 
+          <button
             onClick={() => navigate('/login?tab=signup')}
-            className="w-full sm:w-auto bg-white text-blue-600 hover:bg-gray-100 px-8 sm:px-12 py-5 sm:py-6 text-lg sm:text-xl font-bold shadow-2xl transform hover:scale-105 transition-all duration-300"
+            className="inline-flex items-center gap-2 px-8 py-4 text-lg font-bold rounded-sm bg-[var(--tk-paper)] text-[var(--tk-ink)] hover:bg-white transition-colors"
           >
             Mulai Transformasi Sekarang
-            <ArrowRight className="ml-2 h-5 w-5 sm:h-6 sm:w-6" />
-          </Button>
+            <ArrowRight className="h-5 w-5" />
+          </button>
         </div>
       </section>
 
-      {/* Benefits Section */}
-      <section className="py-20 bg-gray-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      {/* Benefits */}
+      <section className="py-16 sm:py-24 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 items-center">
             <div>
-              <Badge variant="secondary" className="mb-6 bg-green-100 text-green-800">
-                <CheckCircle className="h-3 w-3 mr-1" />
-                Solusi Lengkap
-              </Badge>
-              <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
-                Mengapa Memilih Smart Laundry POS?
+              <span className="tk-eyebrow mb-6">Solusi Lengkap</span>
+              <h2 className="text-3xl md:text-4xl font-bold text-[var(--tk-graphite)] mb-5">
+                Mengapa memilih Smart Laundry POS?
               </h2>
-              <p className="text-lg text-gray-600 mb-8">
-                Dibuat khusus untuk bisnis laundry Indonesia dengan metode pembayaran lokal, 
-                harga dalam Rupiah, dan fitur-fitur yang penting untuk operasional harian Anda.
+              <p className="text-lg text-[var(--tk-ink-soft)] mb-8">
+                Dibuat khusus untuk bisnis laundry Indonesia dengan metode pembayaran lokal, harga dalam
+                Rupiah, dan fitur-fitur yang penting untuk operasional harian Anda.
               </p>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                {benefits.map((benefit, index) => (
-                  <div key={index} className="flex items-center">
-                    <CheckCircle className="h-5 w-5 text-green-500 mr-3 flex-shrink-0" />
-                    <span className="text-gray-700">{benefit}</span>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-3">
+                {benefits.map((benefit) => (
+                  <div key={benefit} className="flex items-center gap-3">
+                    <span className="tk-mono text-[var(--tk-paid)] font-bold">✓</span>
+                    <span className="text-[var(--tk-graphite)]">{benefit}</span>
                   </div>
                 ))}
               </div>
             </div>
-            <div className="relative">
-              <div className="bg-gradient-to-r from-blue-600 to-indigo-600 rounded-2xl p-8 text-white">
-                <div className="mb-6">
-                  <Smartphone className="h-12 w-12 mb-4" />
-                  <h3 className="text-2xl font-bold mb-2">Install sebagai Aplikasi Mobile</h3>
-                  <p className="opacity-90">
-                    Dapatkan pengalaman mobile lengkap dengan dukungan offline dan akses instan
-                  </p>
+
+            <div className="tk-boarding rounded-sm p-8 sm:p-10">
+              <Smartphone className="h-10 w-10 mb-4 text-[var(--tk-carbon)]" />
+              <h3 className="text-2xl font-bold mb-2">Install sebagai Aplikasi Mobile</h3>
+              <p className="opacity-80 mb-6">
+                Dapatkan pengalaman mobile lengkap dengan dukungan offline dan akses instan dari layar utama.
+              </p>
+              <div className="space-y-3 tk-mono text-sm">
+                <div className="flex items-center gap-3">
+                  <Wifi className="h-4 w-4 flex-shrink-0" />
+                  <span>Bekerja offline saat diperlukan</span>
                 </div>
-                <div className="space-y-4">
-                  <div className="flex items-center">
-                    <Wifi className="h-5 w-5 mr-3" />
-                    <span>Bekerja offline saat diperlukan</span>
-                  </div>
-                  <div className="flex items-center">
-                    <Zap className="h-5 w-5 mr-3" />
-                    <span>Performa super cepat</span>
-                  </div>
-                  <div className="flex items-center">
-                    <Globe className="h-5 w-5 mr-3" />
-                    <span>Akses dari mana saja</span>
-                  </div>
+                <div className="flex items-center gap-3">
+                  <Zap className="h-4 w-4 flex-shrink-0" />
+                  <span>Performa super cepat</span>
+                </div>
+                <div className="flex items-center gap-3">
+                  <Globe className="h-4 w-4 flex-shrink-0" />
+                  <span>Akses dari mana saja</span>
                 </div>
               </div>
             </div>
@@ -535,109 +576,107 @@ export const LandingPage: React.FC = () => {
         </div>
       </section>
 
-      {/* CTA Section with Bonus */}
-      <section className="py-20 bg-gradient-to-br from-green-400 via-blue-500 to-purple-600">
-        <div className="max-w-5xl mx-auto text-center px-4 sm:px-6 lg:px-8">
-          <Badge className="mb-6 bg-yellow-400 text-yellow-900 text-base px-6 py-2 shadow-lg">
-            <Gift className="h-4 w-4 mr-2" />
-            🎁 Penawaran Spesial
-          </Badge>
-          <h2 className="text-3xl md:text-5xl font-bold text-white mb-8 leading-tight">
-            Siap Modernisasi Bisnis Laundry Anda?
+      {/* CTA */}
+      <section className="pb-20 sm:pb-28 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-4xl mx-auto text-center bg-[#fffdf8] border border-[var(--tk-line)] rounded-sm p-8 sm:p-14">
+          <span className="tk-eyebrow mb-6">Penawaran untuk Pemilik Toko Baru</span>
+          <h2 className="text-3xl md:text-4xl font-bold text-[var(--tk-graphite)] mb-6 leading-tight">
+            Siap modernisasi bisnis laundry Anda?
           </h2>
-          <p className="text-xl md:text-2xl text-white mb-8 font-medium">
-            Bergabunglah dengan ratusan bisnis laundry yang sudah menggunakan Smart Laundry POS untuk meningkatkan efisiensi dan kepuasan pelanggan.
+          <p className="text-lg text-[var(--tk-ink-soft)] mb-10 max-w-2xl mx-auto">
+            Bergabunglah dengan bisnis laundry yang sudah menggunakan Smart Laundry POS untuk meningkatkan
+            efisiensi dan kepuasan pelanggan.
           </p>
 
-          {/* Bonus Features */}
-          <div className="bg-white/10 backdrop-blur-sm border-2 border-white/30 rounded-3xl p-8 mb-10">
-            <div className="grid md:grid-cols-3 gap-6 text-white">
-              <div className="bg-white/10 rounded-xl p-6 transform hover:scale-105 transition-all duration-300">
-                <CheckCircle className="h-12 w-12 mx-auto mb-4 text-green-300" />
-                <p className="text-xl font-bold mb-2">Mulai gratis</p>
-                <p className="text-sm text-blue-100">Tidak perlu kartu kredit</p>
-              </div>
-              <div className="bg-white/10 rounded-xl p-6 transform hover:scale-105 transition-all duration-300">
-                <Clock className="h-12 w-12 mx-auto mb-4 text-blue-300" />
-                <p className="text-xl font-bold mb-2">Set-up dalam 5 menit</p>
-                <p className="text-sm text-blue-100">Rasakan bedanya hari ini</p>
-              </div>
-              <div className="bg-white/10 rounded-xl p-6 transform hover:scale-105 transition-all duration-300">
-                <Zap className="h-12 w-12 mx-auto mb-4 text-yellow-300" />
-                <p className="text-xl font-bold mb-2">Langsung bisa dimulai</p>
-                <p className="text-sm text-blue-100">Tanpa kontrak jangka panjang</p>
-              </div>
+          <div className="grid sm:grid-cols-3 gap-4 mb-10 text-left">
+            <div className="tk-stub rounded-sm !p-5">
+              <div className="tk-stub__num">A</div>
+              <p className="font-bold text-[var(--tk-graphite)] mb-1">Mulai gratis</p>
+              <p className="text-sm text-[var(--tk-graphite-soft)]">Tidak perlu kartu kredit</p>
+            </div>
+            <div className="tk-stub rounded-sm !p-5">
+              <div className="tk-stub__num">B</div>
+              <p className="font-bold text-[var(--tk-graphite)] mb-1">Set-up 5 menit</p>
+              <p className="text-sm text-[var(--tk-graphite-soft)]">Rasakan bedanya hari ini</p>
+            </div>
+            <div className="tk-stub rounded-sm !p-5">
+              <div className="tk-stub__num">C</div>
+              <p className="font-bold text-[var(--tk-graphite)] mb-1">Langsung mulai</p>
+              <p className="text-sm text-[var(--tk-graphite-soft)]">Tanpa kontrak jangka panjang</p>
             </div>
           </div>
 
-          <Button 
-            size="lg" 
-            onClick={() => navigate('/login?tab=signup')}
-            className="w-full sm:w-auto bg-white text-blue-600 hover:bg-gray-100 px-8 sm:px-12 py-5 sm:py-6 text-lg sm:text-xl font-bold shadow-2xl transform hover:scale-105 transition-all duration-300 hover:shadow-yellow-400/50"
-          >
-            <span className="truncate">👉 Coba Smart Laundry POS Sekarang!</span>
-            <ArrowRight className="ml-2 h-5 w-5 sm:h-6 sm:w-6 flex-shrink-0" />
-          </Button>
-
-          <p className="mt-6 text-lg text-white font-semibold">
-            Tanpa biaya setup • Tanpa kontrak jangka panjang • Langsung bisa dimulai
-          </p>
+          <div className="tk-tear pt-8">
+            <button
+              onClick={() => navigate('/login?tab=signup')}
+              className="inline-flex items-center gap-2 px-8 sm:px-10 py-4 text-lg font-bold rounded-sm bg-[var(--tk-ink)] text-[var(--tk-paper)] hover:bg-[var(--tk-graphite)] transition-colors"
+            >
+              Ambil Tiket Gratis Sekarang
+              <ArrowRight className="h-5 w-5" />
+            </button>
+            <p className="mt-5 text-sm tk-mono uppercase tracking-wide text-[var(--tk-graphite-soft)]">
+              Tanpa biaya setup &middot; Tanpa kontrak &middot; Langsung mulai
+            </p>
+          </div>
         </div>
       </section>
 
       {/* Footer */}
-      <footer className="bg-gray-900 text-white py-12">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
+      <footer className="tk-ink-band py-14 px-4 sm:px-6 lg:px-8">
+        <div className="max-w-7xl mx-auto">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-10">
             <div className="col-span-1 md:col-span-2">
-              <div className="flex items-center mb-4">
-                <div className="w-8 h-8 bg-gradient-to-r from-blue-500 to-indigo-500 rounded-lg flex items-center justify-center mr-3">
-                  <span className="text-white font-bold">SL</span>
+              <div className="flex items-center gap-3 mb-4">
+                <div className="w-9 h-9 border-2 border-[var(--tk-paper)] rounded-sm flex items-center justify-center tk-mono font-bold text-sm">
+                  SL
                 </div>
-                <span className="text-xl font-bold">Smart Laundry POS</span>
+                <span className="text-lg font-bold">Smart Laundry POS</span>
               </div>
-              <p className="text-gray-400 mb-4 max-w-md">
-                Sistem point of sale modern yang dirancang khusus untuk bisnis laundry. 
-                Sederhanakan operasional, tingkatkan efisiensi, dan kembangkan bisnis Anda.
+              <p className="opacity-75 mb-6 max-w-md">
+                Sistem point of sale modern yang dirancang khusus untuk bisnis laundry. Sederhanakan
+                operasional, tingkatkan efisiensi, dan kembangkan bisnis Anda.
               </p>
-              <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 mb-4">
-                <PWAInstallButton variant="outline" />
-                <Button 
+              <div className="flex flex-col sm:flex-row gap-3 mb-6">
+                <PWAInstallButton
                   variant="outline"
+                  className="!bg-transparent !border-white/25 !text-[var(--tk-paper)] hover:!bg-white/10"
+                />
+                <button
                   onClick={() => navigate('/install')}
-                  className="border-gray-600 text-gray-300 hover:bg-gray-700 w-full sm:w-auto"
+                  className="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium border border-white/25 rounded-sm hover:bg-white/10 transition-colors"
                 >
-                  <Download className="h-4 w-4 mr-2" />
+                  <Download className="h-4 w-4" />
                   Install Guide
-                </Button>
+                </button>
               </div>
-              <div className="text-gray-400">
-                <p className="mb-2">
-                  <strong>Kontak:</strong> 
-                  <a href="mailto:fahrudinjaya@gmail.com" className="text-blue-400 hover:text-blue-300 ml-2">
+              <div className="opacity-80 text-sm">
+                <p className="mb-1">
+                  <strong className="opacity-100">Kontak:</strong>{' '}
+                  <a
+                    href="mailto:fahrudinjaya@gmail.com"
+                    className="underline decoration-white/30 hover:decoration-white"
+                  >
                     fahrudinjaya@gmail.com
                   </a>
                 </p>
-                <p className="text-sm">
-                  Untuk pertanyaan, dukungan teknis, atau demo produk
-                </p>
+                <p>Untuk pertanyaan, dukungan teknis, atau demo produk</p>
               </div>
             </div>
-            
+
             <div>
-              <h3 className="text-lg font-semibold mb-4">Fitur</h3>
-              <ul className="space-y-2 text-gray-400">
+              <h3 className="tk-mono text-xs uppercase tracking-widest mb-4 opacity-70">Fitur</h3>
+              <ul className="space-y-2 opacity-80 text-sm">
                 <li>Manajemen Pesanan</li>
                 <li>Database Pelanggan</li>
                 <li>Proses Pembayaran</li>
-                <li>Laporan & Analitik</li>
+                <li>Laporan &amp; Analitik</li>
                 <li>Dukungan Multi-toko</li>
               </ul>
             </div>
-            
+
             <div>
-              <h3 className="text-lg font-semibold mb-4">Dukungan</h3>
-              <ul className="space-y-2 text-gray-400">
+              <h3 className="tk-mono text-xs uppercase tracking-widest mb-4 opacity-70">Dukungan</h3>
+              <ul className="space-y-2 opacity-80 text-sm">
                 <li>Dokumentasi</li>
                 <li>Tutorial Video</li>
                 <li>Customer Support</li>
@@ -646,25 +685,28 @@ export const LandingPage: React.FC = () => {
               </ul>
             </div>
           </div>
-          
-          <div className="border-t border-gray-800 mt-8 pt-8 text-center text-gray-400">
+
+          <div className="border-t border-white/15 mt-10 pt-8 text-center opacity-70 text-sm">
             <p>&copy; 2025 Smart Laundry POS. Dibuat untuk bisnis laundry Indonesia.</p>
-            <p className="mt-2 text-sm">
-              Kontak: <a href="mailto:fahrudinjaya@gmail.com" className="text-blue-400 hover:text-blue-300">fahrudinjaya@gmail.com</a>
+            <p className="mt-2">
+              Kontak:{' '}
+              <a href="mailto:fahrudinjaya@gmail.com" className="underline decoration-white/30 hover:decoration-white">
+                fahrudinjaya@gmail.com
+              </a>
             </p>
           </div>
         </div>
       </footer>
 
-      {/* Sticky mobile CTA — keeps signup one tap away while scrolling (mobile only) */}
-      <div className="sm:hidden fixed bottom-0 left-0 right-0 z-40 bg-white/95 backdrop-blur-sm border-t border-gray-200 px-4 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
-        <Button
+      {/* Sticky mobile CTA */}
+      <div className="sm:hidden fixed bottom-0 left-0 right-0 z-40 bg-[rgba(245,240,228,0.95)] backdrop-blur-sm border-t border-[var(--tk-line)] px-4 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))]">
+        <button
           onClick={() => navigate('/login?tab=signup')}
-          className="w-full bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-700 hover:to-indigo-700 text-white py-5 text-base font-bold shadow-lg pr-20"
+          className="w-full inline-flex items-center justify-center gap-2 rounded-sm bg-[var(--tk-ink)] text-[var(--tk-paper)] py-4 text-base font-bold"
         >
-          <span className="truncate">👉 Coba Gratis Sekarang</span>
-          <ArrowRight className="ml-2 h-5 w-5 flex-shrink-0" />
-        </Button>
+          Ambil Tiket Gratis
+          <ArrowUpRight className="h-5 w-5" />
+        </button>
       </div>
 
       {/* WhatsApp Floating Button */}


### PR DESCRIPTION
## Summary
Replaces the landing page's generic gradient/emoji SaaS look with a design grounded in the actual artifact of the business: the perforated duplicate claim ticket handed over at a laundry counter.

- New type pairing — IBM Plex Mono for ticket numerals/data, IBM Plex Sans for body — loaded only while the landing page is mounted, so authenticated app sessions never pay for the extra font download.
- New paper / carbon-copy / ink-stamp color system, scoped entirely to this page (`.tk-page` in the new `src/pages/LandingPage.css`). Does **not** touch the app-wide `--primary`/`--background` tokens in `src/index.css` that the authenticated POS UI relies on.
- Signature motifs used throughout: perforation dividers between sections, torn-edge "ticket stub" cards (`clip-path` + `drop-shadow`, so the shadow follows the torn silhouette), rotated ink-stamp badges, and ticket-serial numbers on feature cards instead of generic 01/02/03 steps.
- One deliberate motion moment (the hero ticket "prints" in on load) plus a subtle hover peel on stub cards — both respect `prefers-reduced-motion`.
- Copy tightened to a more specific, less emoji-heavy voice. All real business content is preserved (7 features, 8 benefits, the Qasir/Pawoon/Majoo comparison table, contact info) — this is a style refactor, not a content rewrite.
- Comparison table checks/crosses restyled as ledger marks with AA-compliant contrast (verified contrast ratios for all new text/background pairs).

No routing, auth, or data-fetching changes — this only touches `SmartHomePage`'s rendered `LandingPage` component.

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] `npx eslint src/pages/LandingPage.tsx` — no issues
- [x] `npm run build` — succeeds; manually verified in the compiled CSS that all arbitrary-value Tailwind classes generated correctly (caught and fixed 3 cases where an opacity modifier on a `var()`-based color silently failed to generate, e.g. `bg-[var(--x)]/5`)
- [ ] Manual visual QA in a browser (mobile + desktop) — no screenshot tooling available in this environment, recommend `npm run dev` and eyeballing before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned the landing page with a ticket- and boarding-pass-inspired visual style.
  * Added refreshed hero, feature, comparison, benefits, CTA, and footer sections.
  * Added visual check, cross, and partial indicators for comparisons.
  * Added animated interactions, responsive layouts, custom typography, and improved focus states.
  * Added a simplified mobile sticky signup button.
* **Accessibility**
  * Reduced animations when requested by system preferences.
  * Added visible keyboard focus outlines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->