### PR TITLE
Fix: Home page cancelled-orders tile navigates to unfiltered list

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -177,7 +177,7 @@ export const HomePage: React.FC = () => {
       icon: XCircle,
       color: 'text-rose-400',
       bgColor: 'bg-rose-50',
-      onClick: () => navigate('/order-history')
+      onClick: () => navigate('/order-history?status=cancelled')
     }
   ].filter(action => !action.hidden);
 

--- a/src/pages/OrderHistoryOptimized.tsx
+++ b/src/pages/OrderHistoryOptimized.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { DateRangePicker } from '@/components/ui/date-range-picker';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useOrders, OrderFilters, Order } from '@/hooks/useOrdersOptimized';
 import { useUpdateOrderStatusWithNotifications } from '@/hooks/useOrdersWithNotifications';
 import { useResendOrderNotification } from '@/hooks/useResendOrderNotification';
@@ -43,7 +43,12 @@ export const OrderHistory = () => {
   const navigate = useNavigate();
   usePageTitle('Riwayat Pesanan');
   const { isOwner } = useStore();
-  
+  const [searchParams] = useSearchParams();
+  // Deep-link support (e.g. Home page's "Pesanan Batal" tile): ?status=cancelled
+  // preselects the execution-status filter and widens the date range so
+  // matching orders aren't hidden behind the default "today" window.
+  const initialExecutionStatus = searchParams.get('status') || 'all';
+
   const [searchTerm, setSearchTerm] = useState('');
   const [debouncedSearchTerm, setDebouncedSearchTerm] = useState('');
   const [selectedOrder, setSelectedOrder] = useState<Order | null>(null);
@@ -56,20 +61,22 @@ export const OrderHistory = () => {
   const [payLaterPaymentOrder, setPayLaterPaymentOrder] = useState<Order | null>(null);
   const [showFilters, setShowFilters] = useState(false);
   const [filters, setFilters] = useState<FilterState>({
-    executionStatus: 'all',
+    executionStatus: initialExecutionStatus,
     paymentStatus: 'all',
     paymentMethod: 'all',
-    dateRange: 'today', // Default to today for better performance on initial load
+    // Default to today for better performance on initial load, unless a
+    // status was deep-linked in, in which case show all matching orders.
+    dateRange: initialExecutionStatus !== 'all' ? 'all' : 'today',
     isOverdue: false,
   });
   const [customDateRange, setCustomDateRange] = useState<DateRange | undefined>();
-  
+
   // Pending filters (before Apply button is clicked)
   const [pendingFilters, setPendingFilters] = useState<FilterState>({
-    executionStatus: 'all',
+    executionStatus: initialExecutionStatus,
     paymentStatus: 'all',
     paymentMethod: 'all',
-    dateRange: 'today', // Default to today for better performance on initial load
+    dateRange: initialExecutionStatus !== 'all' ? 'all' : 'today',
     isOverdue: false,
   });
   const [pendingCustomDateRange, setPendingCustomDateRange] = useState<DateRange | undefined>();


### PR DESCRIPTION
## Summary
- The Home page's "Pesanan Batal" quick-action tile navigated to `/order-history` with no filter, landing the user on the full unfiltered order list instead of cancelled orders specifically.
- `OrderHistoryOptimized` now reads a `?status=` query param on load to preselect the execution-status filter (e.g. `status=cancelled`), and widens the default date range from "today" to "all" when a status is deep-linked in, so older cancelled orders aren't hidden behind the default window.
- The Home tile now links to `/order-history?status=cancelled`.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/pages/HomePage.tsx src/pages/OrderHistoryOptimized.tsx` (no new issues; pre-existing `any` warnings unrelated to this change)
- [x] `npm run build`
- [ ] Manual: tap "Pesanan Batal" on Home, confirm Order History opens with "Dibatalkan" preselected in the status filter and shows cancelled orders regardless of date
- [ ] Manual: navigating to `/order-history` directly (no query param) still defaults to "Semua Status" / "Hari Ini" as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Order history links can now open with a preselected execution-status filter.
  - Filtered order history results are no longer limited to today’s date when a non-default status is selected.

- **Bug Fixes**
  - The cancelled-orders quick action now opens order history with cancelled orders already selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->