### PR TITLE
Add "Daftar Pesanan" quick action to Home page

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -20,6 +20,7 @@ import {
   QrCode,
   Package,
   XCircle,
+  ClipboardList,
   TrendingUp,
   TrendingDown,
   Home as HomeIcon,
@@ -126,6 +127,14 @@ export const HomePage: React.FC = () => {
       color: 'text-rose-400',
       bgColor: 'bg-rose-50',
       onClick: () => navigate('/pos')
+    },
+    {
+      id: 'order-list',
+      title: 'Daftar Pesanan',
+      icon: ClipboardList,
+      color: 'text-rose-400',
+      bgColor: 'bg-rose-50',
+      onClick: () => navigate('/order-history')
     },
     {
       id: 'customers',


### PR DESCRIPTION
## Summary
- Home page's quick-actions grid had no direct link to the full order list, only to cancelled orders specifically.
- Add a "Daftar Pesanan" tile (ClipboardList icon) that navigates to `/order-history`, placed right after the primary "Buat Pesanan" action.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/pages/HomePage.tsx`
- [x] `npm run build`
- [ ] Manual: tap "Daftar Pesanan" on Home (mobile and desktop), confirm it opens `/order-history` with default (unfiltered, today) view

🤖 Generated with [Claude Code](https://claude.com/claude-code)