### PR TITLE
Remove disabled "coming soon" quick actions from Home

### DIFF
--- a/src/components/home/MobileHomeView.tsx
+++ b/src/components/home/MobileHomeView.tsx
@@ -17,7 +17,6 @@ export interface QuickAction {
   title: string;
   icon: LucideIcon;
   onClick: () => void;
-  disabled?: boolean;
 }
 
 export interface BottomNavItem {
@@ -191,11 +190,7 @@ export const MobileHomeView: React.FC<MobileHomeViewProps> = ({
             <button
               key={action.id}
               onClick={action.onClick}
-              disabled={action.disabled}
-              className={cn(
-                'flex flex-col items-center justify-center rounded-2xl border border-border bg-card p-4 shadow-soft transition-shadow hover:shadow-medium active:scale-95',
-                action.disabled && 'cursor-not-allowed opacity-50'
-              )}
+              className="flex flex-col items-center justify-center rounded-2xl border border-border bg-card p-4 shadow-soft transition-shadow hover:shadow-medium active:scale-95"
             >
               <div className="mb-2 flex h-12 w-12 items-center justify-center rounded-xl bg-pos-highlight/40">
                 <action.icon className="h-6 w-6 text-primary" />

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -16,8 +16,6 @@ import {
   Plus,
   Users,
   Wrench,
-  CreditCard,
-  QrCode,
   Package,
   XCircle,
   ClipboardList,
@@ -159,26 +157,7 @@ export const HomePage: React.FC = () => {
       icon: Package,
       color: 'text-rose-400',
       bgColor: 'bg-rose-50',
-      onClick: () => navigate('/expenses'),
-      disabled: false
-    },
-    {
-      id: 'scan-qr',
-      title: 'Scan Kode QR',
-      icon: QrCode,
-      color: 'text-rose-400',
-      bgColor: 'bg-rose-50',
-      onClick: () => navigate('/order-history'), // Navigate to order history for now
-      disabled: true // Mark as coming soon
-    },
-    {
-      id: 'payment-methods',
-      title: 'Metode Pembayaran',
-      icon: CreditCard,
-      color: 'text-rose-400',
-      bgColor: 'bg-rose-50',
-      onClick: () => navigate('/order-history'), // Navigate to order history for now
-      disabled: true // Mark as coming soon
+      onClick: () => navigate('/expenses')
     },
     {
       id: 'cancelled-orders',
@@ -190,12 +169,8 @@ export const HomePage: React.FC = () => {
     }
   ].filter(action => !action.hidden);
 
-  // Grid excludes "new-order" (promoted to a full-width hero button) and, for
-  // new stores, hides the disabled "coming soon" tiles so the grid only shows
-  // functional actions.
-  const gridActions = quickActions.filter(
-    (action) => action.id !== 'new-order' && !(showOnboarding && action.disabled)
-  );
+  // Grid excludes "new-order" - it's promoted to a full-width hero button instead.
+  const gridActions = quickActions.filter((action) => action.id !== 'new-order');
 
   const bottomNavItems = [
     {
@@ -399,10 +374,7 @@ export const HomePage: React.FC = () => {
             <button
               key={action.id}
               onClick={action.onClick}
-              disabled={action.disabled}
-              className={`flex flex-col items-center justify-center p-4 bg-white rounded-2xl shadow-md hover:shadow-lg transition-shadow active:scale-95 ${
-                action.disabled ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
+              className="flex flex-col items-center justify-center p-4 bg-white rounded-2xl shadow-md hover:shadow-lg transition-shadow active:scale-95"
             >
               <div className={`w-12 h-12 ${action.bgColor} rounded-xl flex items-center justify-center mb-2`}>
                 <action.icon className={`h-6 w-6 ${action.color}`} />


### PR DESCRIPTION
## Summary
- Remove the "Scan Kode QR" and "Metode Pembayaran" quick-action tiles - both were placeholders (`disabled: true`, navigating to `/order-history` as a stand-in), not real features.
- Clean up the now-dead `disabled` plumbing that only existed to support those two tiles: the onboarding-hiding clause in `gridActions`, the disabled/opacity styling and `disabled` attribute in both the desktop grid (`HomePage.tsx`) and the mobile grid (`MobileHomeView.tsx`), and the `disabled` field on the `QuickAction` type.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/pages/HomePage.tsx src/components/home/MobileHomeView.tsx` (no issues)
- [x] `npm run build`
- [ ] Manual: confirm the Home quick-actions grid (both desktop and mobile) no longer shows the two removed tiles, and the remaining tiles still work for both owner and staff roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled all quick actions on the home screen, including expense-related actions.
  * Quick-action buttons now remain visible and interactive during onboarding.
  * Removed disabled states and styling that could prevent access to available actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->