### PR TITLE
feat(android): printer BLE fix, shared bottom nav, native affordances, screen restyle

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -18,6 +18,10 @@ on:
       - 'package.json'
       - 'package-lock.json'
       - 'vite.config.ts'
+      - 'tsconfig*.json'
+      - 'tailwind.config.ts'
+      - 'postcss.config.js'
+      - 'components.json'
       - '.github/workflows/build-android.yml'
   workflow_dispatch: {}
 

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -8,17 +8,6 @@ name: Build Android
 # sideloading onto a test device - not for a Play Store release.
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'src/**'
-      - 'public/**'
-      - 'index.html'
-      - 'capacitor.config.ts'
-      - 'package.json'
-      - 'package-lock.json'
-      - 'vite.config.ts'
-      - '.github/workflows/build-android.yml'
   push:
     branches: [main]
     paths:

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -1,0 +1,86 @@
+name: Build Android
+
+# This repo doesn't check the generated android/ native project into git (see
+# capacitor.config.ts) - this workflow regenerates it fresh from the web build
+# every run via `cap add`/`cap sync`, then builds a debug APK with Gradle.
+# There's no release signing set up yet, so this produces a debug build only,
+# good for verifying the Capacitor+Gradle pipeline still builds and for
+# sideloading onto a test device - not for a Play Store release.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'index.html'
+      - 'capacitor.config.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.ts'
+      - '.github/workflows/build-android.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'public/**'
+      - 'index.html'
+      - 'capacitor.config.ts'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.ts'
+      - '.github/workflows/build-android.yml'
+  workflow_dispatch: {}
+
+concurrency:
+  group: build-android-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web app
+        run: npm run build
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Add Android platform
+        run: npx cap add android
+
+      - name: Sync web build into native project
+        run: npx cap sync android
+
+      - name: Build debug APK
+        working-directory: android
+        run: ./gradlew assembleDebug --no-daemon
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: smart-laundry-pos-debug-apk
+          path: android/app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 14
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ public/favicon-generator.html
 
 research/
 .env*
+
+# Generated Capacitor native project - CI (.github/workflows/build-android.yml)
+# regenerates this fresh from the web build via `cap add android` on every run.
+android/
+ios/

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -3,7 +3,16 @@ import type { CapacitorConfig } from '@capacitor/cli';
 const config: CapacitorConfig = {
   appId: 'com.smartlaundry.pos',
   appName: 'Smart Laundry POS',
-  webDir: 'dist'
+  webDir: 'dist',
+  plugins: {
+    SplashScreen: {
+      // Keep the native splash up until the app explicitly hides it (see main.tsx),
+      // instead of racing a fixed timeout against React's first paint.
+      launchAutoHide: false,
+      backgroundColor: '#2563eb',
+      androidScaleType: 'CENTER_CROP',
+    },
+  },
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite_react_shadcn_ts",
       "version": "0.0.0",
       "dependencies": {
+        "@capacitor-community/bluetooth-le": "^7.3.2",
         "@capacitor/android": "^7.4.3",
         "@capacitor/cli": "^7.4.3",
         "@capacitor/core": "^7.4.3",
@@ -164,6 +165,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@capacitor-community/bluetooth-le": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@capacitor-community/bluetooth-le/-/bluetooth-le-7.3.2.tgz",
+      "integrity": "sha512-7dgtglFXGmyS849XtIZ62iA997aE3yqNsq7XsC8yjR8dqe/agh852+nW1Zk/8QlG58dPu/K5fxVzlWZvZFb80g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.20"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
       }
     },
     "node_modules/@capacitor/android": {
@@ -3431,6 +3444,12 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
+      "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,11 @@
       "dependencies": {
         "@capacitor-community/bluetooth-le": "^7.3.2",
         "@capacitor/android": "^7.4.3",
+        "@capacitor/app": "^7.1.2",
         "@capacitor/cli": "^7.4.3",
         "@capacitor/core": "^7.4.3",
+        "@capacitor/splash-screen": "^7.0.5",
+        "@capacitor/status-bar": "^7.0.6",
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
@@ -188,6 +191,15 @@
         "@capacitor/core": "^7.4.0"
       }
     },
+    "node_modules/@capacitor/app": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/app/-/app-7.1.2.tgz",
+      "integrity": "sha512-d4I/oF/PRu4megL7/IGKYfe5j7yzSON1FRFgq6kH+m5kH6g7V+wyjHRLauCzGNjdRx4S+nWOumINds0qcRBtKg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
     "node_modules/@capacitor/cli": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/@capacitor/cli/-/cli-7.4.3.tgz",
@@ -236,6 +248,24 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@capacitor/splash-screen": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@capacitor/splash-screen/-/splash-screen-7.0.5.tgz",
+      "integrity": "sha512-bPG2SamFL7VT5I3XsgsGgJhkiyxq3OXCOVKEDupSieVdtEiG7j2vLbSD0xL+91zteF/qLuxsjbugGy5LD8mS2A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capacitor/status-bar": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-7.0.6.tgz",
+      "integrity": "sha512-7AVqj46b26QikImQzWfsJmzG8NUJZBGkrVSuoeTo+SX/YH3hXH0MqwwFgMqMGHfa/BICDgSvTjM9miVFlq0+RQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@capacitor-community/bluetooth-le": "^7.3.2",
     "@capacitor/android": "^7.4.3",
     "@capacitor/cli": "^7.4.3",
     "@capacitor/core": "^7.4.3",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,11 @@
   "dependencies": {
     "@capacitor-community/bluetooth-le": "^7.3.2",
     "@capacitor/android": "^7.4.3",
+    "@capacitor/app": "^7.1.2",
     "@capacitor/cli": "^7.4.3",
     "@capacitor/core": "^7.4.3",
+    "@capacitor/splash-screen": "^7.0.5",
+    "@capacitor/status-bar": "^7.0.6",
     "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { OwnerRoute } from "./components/auth/OwnerRoute";
 import { ProtectedRedirect } from "./components/auth/ProtectedRedirect";
 import { AppLayout } from "./components/layout/AppLayout";
 import { AndroidBackButtonHandler } from "./components/layout/AndroidBackButtonHandler";
+import { NativeSplashScreenHider } from "./components/layout/NativeSplashScreenHider";
 import { queryClient } from "./lib/queryClient";
 import { PublicReceiptPage } from "./pages/PublicReceiptPage";
 import { PWAManagementPage } from "./pages/PWAManagementPage";
@@ -31,8 +32,9 @@ import { RevenueReportPage } from "./pages/RevenueReportPage";
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
+      <NativeSplashScreenHider />
       <Toaster />
-      <Sonner 
+      <Sonner
         position="top-center"
         richColors
         closeButton

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { ProtectedRoute } from "./components/auth/ProtectedRoute";
 import { OwnerRoute } from "./components/auth/OwnerRoute";
 import { ProtectedRedirect } from "./components/auth/ProtectedRedirect";
 import { AppLayout } from "./components/layout/AppLayout";
+import { AndroidBackButtonHandler } from "./components/layout/AndroidBackButtonHandler";
 import { queryClient } from "./lib/queryClient";
 import { PublicReceiptPage } from "./pages/PublicReceiptPage";
 import { PWAManagementPage } from "./pages/PWAManagementPage";
@@ -47,6 +48,7 @@ const App = () => (
         }}
       />
       <BrowserRouter>
+        <AndroidBackButtonHandler />
         <AuthProvider>
           <StoreProvider>
             <ThermalPrinterProvider>

--- a/src/components/home/MobileHomeView.tsx
+++ b/src/components/home/MobileHomeView.tsx
@@ -19,14 +19,6 @@ export interface QuickAction {
   onClick: () => void;
 }
 
-export interface BottomNavItem {
-  id: string;
-  title: string;
-  icon: LucideIcon;
-  active: boolean;
-  onClick: () => void;
-}
-
 interface MobileHomeViewProps {
   greeting: string;
   greetingName: string;
@@ -43,7 +35,6 @@ interface MobileHomeViewProps {
   totalSteps: number;
   onCreateOrder: () => void;
   gridActions: QuickAction[];
-  bottomNavItems: BottomNavItem[];
 }
 
 export const MobileHomeView: React.FC<MobileHomeViewProps> = ({
@@ -62,10 +53,9 @@ export const MobileHomeView: React.FC<MobileHomeViewProps> = ({
   totalSteps,
   onCreateOrder,
   gridActions,
-  bottomNavItems,
 }) => {
   return (
-    <div className="pb-24">
+    <div>
       {/* Hero: edge-to-edge via negative margins canceling AppLayout's padding */}
       <div className="relative -mx-4 -mt-4 overflow-hidden rounded-b-[2rem] bg-gradient-primary px-5 pt-8 pb-10 text-primary-foreground shadow-medium sm:-mx-6 sm:-mt-6">
         <div
@@ -198,35 +188,6 @@ export const MobileHomeView: React.FC<MobileHomeViewProps> = ({
               <p className="text-center text-xs font-medium leading-tight text-foreground">
                 {action.title}
               </p>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Bottom Navigation Bar */}
-      <div
-        className="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-card shadow-medium"
-        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
-      >
-        <div className="mx-auto flex max-w-md justify-center gap-4 px-4">
-          {bottomNavItems.map((item) => (
-            <button
-              key={item.id}
-              onClick={item.onClick}
-              className={cn(
-                'flex max-w-[120px] flex-1 flex-col items-center justify-center gap-1 py-2.5 transition-colors',
-                item.active ? 'text-primary' : 'text-muted-foreground hover:text-foreground'
-              )}
-            >
-              <div
-                className={cn(
-                  'flex h-8 w-8 items-center justify-center rounded-full',
-                  item.active && 'bg-pos-highlight/50'
-                )}
-              >
-                <item.icon className="h-5 w-5" />
-              </div>
-              <span className="text-[11px] font-medium">{item.title}</span>
             </button>
           ))}
         </div>

--- a/src/components/layout/AndroidBackButtonHandler.tsx
+++ b/src/components/layout/AndroidBackButtonHandler.tsx
@@ -1,0 +1,10 @@
+import { useAndroidBackButton } from '@/hooks/useAndroidBackButton';
+
+/**
+ * Renders nothing - just activates the Android hardware Back button wiring
+ * for the whole app. Needs to live inside <BrowserRouter>.
+ */
+export const AndroidBackButtonHandler = (): null => {
+  useAndroidBackButton();
+  return null;
+};

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -20,7 +20,10 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
       <AppSidebar />
       <SidebarInset className="w-full overflow-x-hidden">
         {/* Top Header Bar with trigger */}
-        <header className="sticky top-0 z-40 flex h-14 shrink-0 items-center gap-2 border-b bg-background px-4">
+        <header
+          className="sticky top-0 z-40 flex min-h-14 shrink-0 items-center gap-2 border-b bg-background px-4"
+          style={{ paddingTop: 'env(safe-area-inset-top)' }}
+        >
           <SidebarTrigger className="-ml-1" />
           <Separator orientation="vertical" className="h-6" />
           <div className="flex-1 min-w-0">

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { SidebarProvider, SidebarInset, SidebarTrigger } from '@/components/ui/sidebar';
+import { Separator } from '@/components/ui/separator';
+import { StoreSelector } from '@/components/stores/StoreSelector';
+import { useMobileBottomNavItems } from '@/hooks/useMobileBottomNavItems';
+import { useStore } from '@/contexts/StoreContext';
 import { AppSidebar } from './AppSidebar';
 import { MobileBottomNav } from './MobileBottomNav';
-import { useStore } from '@/contexts/StoreContext';
-import { StoreSelector } from '@/components/stores/StoreSelector';
-import { Separator } from '@/components/ui/separator';
-import { useMobileBottomNavItems } from '@/hooks/useMobileBottomNavItems';
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -40,7 +40,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
         </header>
         {/* Main Content */}
         <main className="flex-1 overflow-x-hidden bg-gray-50">
-          <div className="mx-auto max-w-7xl px-4 pt-4 pb-24 sm:px-6 sm:pt-6 lg:px-8 lg:pt-8 md:pb-6 lg:pb-8">
+          <div className="mx-auto max-w-7xl px-4 pt-4 pb-[calc(6rem+env(safe-area-inset-bottom))] sm:px-6 sm:pt-6 lg:px-8 lg:pt-8 md:pb-6 lg:pb-8">
             {children}
           </div>
         </main>

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { SidebarProvider, SidebarInset, SidebarTrigger } from '@/components/ui/sidebar';
 import { AppSidebar } from './AppSidebar';
+import { MobileBottomNav } from './MobileBottomNav';
 import { useStore } from '@/contexts/StoreContext';
 import { StoreSelector } from '@/components/stores/StoreSelector';
 import { Separator } from '@/components/ui/separator';
+import { useMobileBottomNavItems } from '@/hooks/useMobileBottomNavItems';
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -11,7 +13,8 @@ interface AppLayoutProps {
 
 export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
   const { isOwner } = useStore();
-  
+  const bottomNavItems = useMobileBottomNavItems();
+
   return (
     <SidebarProvider defaultOpen={false}>
       <AppSidebar />
@@ -34,10 +37,11 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
         </header>
         {/* Main Content */}
         <main className="flex-1 overflow-x-hidden bg-gray-50">
-          <div className="mx-auto max-w-7xl px-4 py-4 sm:px-6 sm:py-6 lg:px-8 lg:py-8">
+          <div className="mx-auto max-w-7xl px-4 pt-4 pb-24 sm:px-6 sm:pt-6 lg:px-8 lg:pt-8 md:pb-6 lg:pb-8">
             {children}
           </div>
         </main>
+        <MobileBottomNav items={bottomNavItems} />
       </SidebarInset>
     </SidebarProvider>
   );

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useStore } from '@/contexts/StoreContext';
 import { useNavigate, useLocation } from 'react-router-dom';
+import { Capacitor } from '@capacitor/core';
 import {
   LogOut,
   History,
@@ -239,16 +240,18 @@ export const AppSidebar: React.FC = () => {
           <SidebarGroupLabel>Pengaturan</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              <SidebarMenuItem>
-                <SidebarMenuButton
-                  onClick={() => handleNavigation('/install')}
-                  isActive={location.pathname === '/install'}
-                  tooltip="Install Aplikasi"
-                >
-                  <Smartphone className="h-4 w-4" />
-                  <span>Install Aplikasi</span>
-                </SidebarMenuButton>
-              </SidebarMenuItem>
+              {!Capacitor.isNativePlatform() && (
+                <SidebarMenuItem>
+                  <SidebarMenuButton
+                    onClick={() => handleNavigation('/install')}
+                    isActive={location.pathname === '/install'}
+                    tooltip="Install Aplikasi"
+                  >
+                    <Smartphone className="h-4 w-4" />
+                    <span>Install Aplikasi</span>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              )}
               <SidebarMenuItem>
                 <ChangePasswordDialog
                   trigger={

--- a/src/components/layout/MobileBottomNav.tsx
+++ b/src/components/layout/MobileBottomNav.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface BottomNavItem {
+  id: string;
+  title: string;
+  icon: LucideIcon;
+  active: boolean;
+  onClick: () => void;
+}
+
+interface MobileBottomNavProps {
+  items: BottomNavItem[];
+}
+
+/**
+ * Persistent bottom tab bar for the app's highest-frequency destinations.
+ * Mobile-only (hidden at the md breakpoint, matching useIsMobile's 768px cutoff);
+ * the full menu (owner-only pages, settings, sign out) stays in the sidebar drawer.
+ */
+export const MobileBottomNav: React.FC<MobileBottomNavProps> = ({ items }) => {
+  return (
+    <div
+      className="fixed inset-x-0 bottom-0 z-30 border-t border-border bg-card shadow-medium md:hidden"
+      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+    >
+      <div className="mx-auto flex max-w-md justify-center gap-4 px-4">
+        {items.map((item) => (
+          <button
+            key={item.id}
+            onClick={item.onClick}
+            className={cn(
+              'flex max-w-[120px] flex-1 flex-col items-center justify-center gap-1 py-2.5 transition-colors',
+              item.active ? 'text-primary' : 'text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <div
+              className={cn(
+                'flex h-8 w-8 items-center justify-center rounded-full',
+                item.active && 'bg-pos-highlight/50'
+              )}
+            >
+              <item.icon className="h-5 w-5" />
+            </div>
+            <span className="text-[11px] font-medium">{item.title}</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/components/layout/NativeSplashScreenHider.tsx
+++ b/src/components/layout/NativeSplashScreenHider.tsx
@@ -1,0 +1,10 @@
+import { useHideNativeSplashScreen } from '@/hooks/useHideNativeSplashScreen';
+
+/**
+ * Renders nothing - just hides the native splash screen once the app has actually
+ * committed its first render, instead of racing it from main.tsx.
+ */
+export const NativeSplashScreenHider = (): null => {
+  useHideNativeSplashScreen();
+  return null;
+};

--- a/src/components/orders/VirtualizedOrderList.tsx
+++ b/src/components/orders/VirtualizedOrderList.tsx
@@ -54,22 +54,22 @@ const OrderItem = memo(({ index, style, data }: {
 
   const getExecutionStatusColor = (status: string) => {
     switch (status) {
-      case 'completed': return 'bg-green-100 text-green-800';
-      case 'ready_for_pickup': return 'bg-emerald-100 text-emerald-800';
-      case 'in_progress': return 'bg-blue-100 text-blue-800';
-      case 'in_queue': return 'bg-yellow-100 text-yellow-800';
-      case 'cancelled': return 'bg-red-100 text-red-800';
-      default: return 'bg-gray-100 text-gray-800';
+      case 'completed': return 'bg-pos-success/10 text-pos-success border border-pos-success/30';
+      case 'ready_for_pickup': return 'bg-pos-warning/10 text-pos-warning border border-pos-warning/30';
+      case 'in_progress': return 'bg-pos-highlight/30 text-primary border border-primary/20';
+      case 'in_queue': return 'bg-pos-highlight/20 text-primary border border-pos-highlight/40';
+      case 'cancelled': return 'bg-destructive/10 text-destructive border border-destructive/30';
+      default: return 'bg-muted text-muted-foreground border border-border';
     }
   };
 
   const getPaymentStatusColor = (status: string) => {
     switch (status) {
-      case 'completed': return 'bg-green-100 text-green-800';
-      case 'down_payment': return 'bg-orange-100 text-orange-800';
-      case 'pending': return 'bg-yellow-100 text-yellow-800';
-      case 'refunded': return 'bg-red-100 text-red-800';
-      default: return 'bg-gray-100 text-gray-800';
+      case 'completed': return 'bg-pos-success/10 text-pos-success border border-pos-success/30';
+      case 'down_payment': return 'bg-pos-highlight/30 text-primary border border-primary/20';
+      case 'pending': return 'bg-pos-warning/10 text-pos-warning border border-pos-warning/30';
+      case 'refunded': return 'bg-destructive/10 text-destructive border border-destructive/30';
+      default: return 'bg-muted text-muted-foreground border border-border';
     }
   };
 
@@ -85,7 +85,7 @@ const OrderItem = memo(({ index, style, data }: {
 
   return (
     <div style={style} className="px-1 sm:px-4">
-      <Card className="mb-2 hover:shadow-md transition-shadow">
+      <Card className="mb-2 hover:shadow-medium transition-shadow">
         <CardContent className="p-2 sm:p-4">
           <div className="flex justify-between items-start">
             <div className="flex-1 min-w-0">
@@ -143,17 +143,17 @@ const OrderItem = memo(({ index, style, data }: {
 
               {/* Down Payment Information */}
               {order.payment_status === 'down_payment' && order.payment_amount !== null && order.payment_amount !== undefined && (
-                <div className="mb-3 p-2 bg-yellow-50 border border-yellow-200 rounded-lg">
+                <div className="mb-3 p-2 bg-pos-warning/10 border border-pos-warning/30 rounded-lg">
                   <div className="grid grid-cols-2 gap-2 text-xs">
                     <div>
-                      <span className="text-yellow-700 font-medium">DP Dibayar: </span>
-                      <span className="font-bold text-yellow-900">
+                      <span className="text-pos-warning font-medium">DP Dibayar: </span>
+                      <span className="font-bold text-pos-warning">
                         Rp{order.payment_amount.toLocaleString('id-ID')}
                       </span>
                     </div>
                     <div>
-                      <span className="text-orange-700 font-medium">Sisa: </span>
-                      <span className="font-bold text-orange-900">
+                      <span className="text-destructive/80 font-medium">Sisa: </span>
+                      <span className="font-bold text-destructive">
                         Rp{(order.total_amount - order.payment_amount).toLocaleString('id-ID')}
                       </span>
                     </div>
@@ -180,7 +180,7 @@ const OrderItem = memo(({ index, style, data }: {
                       variant="outline"
                       size="sm"
                       onClick={() => data.onViewReceipt!(order.id)}
-                      className="flex items-center justify-center space-x-1 text-xs border-blue-200 text-blue-700 hover:bg-blue-50"
+                      className="flex items-center justify-center space-x-1 text-xs border-primary/30 text-primary hover:bg-primary/5"
                     >
                       <Receipt className="h-3 w-3" />
                       <span>Struk</span>
@@ -194,7 +194,7 @@ const OrderItem = memo(({ index, style, data }: {
                     variant="outline"
                     size="sm"
                     onClick={() => data.onPrintThermal!(order.id)}
-                    className="w-full flex items-center justify-center space-x-1 text-xs border-green-200 text-green-700 hover:bg-green-50"
+                    className="w-full flex items-center justify-center space-x-1 text-xs border-primary/30 text-primary hover:bg-primary/5"
                   >
                     <Printer className="h-3 w-3" />
                     <span>Cetak Struk</span>
@@ -208,7 +208,7 @@ const OrderItem = memo(({ index, style, data }: {
                     size="sm"
                     onClick={() => data.onResendNotification!(order.id)}
                     disabled={isButtonLoading(order.id, 'resend_notification')}
-                    className="w-full flex items-center justify-center space-x-1 text-xs border-green-200 text-green-700 hover:bg-green-50"
+                    className="w-full flex items-center justify-center space-x-1 text-xs border-primary/30 text-primary hover:bg-primary/5"
                   >
                     {isButtonLoading(order.id, 'resend_notification') ? (
                       <>
@@ -231,7 +231,7 @@ const OrderItem = memo(({ index, style, data }: {
                     size="sm"
                     onClick={() => onUpdateExecution(order.id, 'in_progress')}
                     disabled={isButtonLoading(order.id, 'execution_in_progress')}
-                    className="w-full text-xs bg-blue-600 hover:bg-blue-700"
+                    className="w-full text-xs"
                   >
                     {isButtonLoading(order.id, 'execution_in_progress') ? (
                       <>
@@ -249,7 +249,7 @@ const OrderItem = memo(({ index, style, data }: {
                     size="sm"
                     onClick={() => onUpdateExecution(order.id, 'ready_for_pickup')}
                     disabled={isButtonLoading(order.id, 'execution_ready_for_pickup')}
-                    className="w-full text-xs bg-orange-600 hover:bg-orange-700"
+                    className="w-full text-xs bg-pos-warning text-white hover:bg-pos-warning/90"
                   >
                     {isButtonLoading(order.id, 'execution_ready_for_pickup') ? (
                       <>
@@ -263,11 +263,11 @@ const OrderItem = memo(({ index, style, data }: {
                 )}
                 {order.execution_status === 'ready_for_pickup' && (
                   <Button
-                    variant="default"
+                    variant="success"
                     size="sm"
                     onClick={() => onUpdateExecution(order.id, 'completed')}
                     disabled={isButtonLoading(order.id, 'execution_completed')}
-                    className="w-full text-xs bg-green-600 hover:bg-green-700"
+                    className="w-full text-xs"
                   >
                     {isButtonLoading(order.id, 'execution_completed') ? (
                       <>
@@ -283,11 +283,11 @@ const OrderItem = memo(({ index, style, data }: {
                 {/* Row 4: Payment Actions */}
                 {order.payment_status === 'pending' && data.onShowPaymentDialog && (
                   <Button
-                    variant="default"
+                    variant="success"
                     size="sm"
                     onClick={() => data.onShowPaymentDialog!(order)}
                     disabled={isButtonLoading(order.id, 'payment')}
-                    className="w-full text-xs bg-green-600 hover:bg-green-700"
+                    className="w-full text-xs"
                   >
                     {isButtonLoading(order.id, 'payment') ? (
                       <>
@@ -305,7 +305,7 @@ const OrderItem = memo(({ index, style, data }: {
                     size="sm"
                     onClick={() => data.onShowPaymentDialog!(order)}
                     disabled={isButtonLoading(order.id, 'payment')}
-                    className="w-full text-xs bg-orange-600 hover:bg-orange-700"
+                    className="w-full text-xs bg-pos-warning text-white hover:bg-pos-warning/90"
                   >
                     {isButtonLoading(order.id, 'payment') ? (
                       <>

--- a/src/components/thermal/ThermalPrinterManager.tsx
+++ b/src/components/thermal/ThermalPrinterManager.tsx
@@ -219,7 +219,7 @@ export const ThermalPrinterManager: React.FC<ThermalPrinterManagerProps> = ({
 
             {printerConnection && (
               <div className="text-sm text-muted-foreground">
-                <p>Terhubung ke: {printerConnection.device.name || printerConnection.device.id}</p>
+                <p>Terhubung ke: {printerConnection.deviceName || printerConnection.deviceId}</p>
               </div>
             )}
           </div>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -51,15 +51,32 @@ interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
   VariantProps<typeof sheetVariants> { }
 
+// Sides that touch the top/bottom of the viewport (inset-y-0) need extra clearance for
+// the status bar / gesture bar on top of their normal p-6 padding; "top"/"bottom" sheets
+// only need it on the edge they're anchored to.
+const SIDE_SAFE_AREA_STYLE: Record<NonNullable<VariantProps<typeof sheetVariants>["side"]>, React.CSSProperties> = {
+  top: { paddingTop: "max(1.5rem, env(safe-area-inset-top))" },
+  bottom: { paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))" },
+  left: {
+    paddingTop: "max(1.5rem, env(safe-area-inset-top))",
+    paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))",
+  },
+  right: {
+    paddingTop: "max(1.5rem, env(safe-area-inset-top))",
+    paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))",
+  },
+}
+
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, ...props }, ref) => (
+>(({ side = "right", className, children, style, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content
       ref={ref}
       className={cn(sheetVariants({ side }), className)}
+      style={{ ...SIDE_SAFE_AREA_STYLE[side ?? "right"], ...style }}
       {...props}
     >
       {children}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -28,17 +28,22 @@ const SheetOverlay = React.forwardRef<
 ))
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
+// Padding is spelled out per-side (instead of a shared p-6 plus overrides) so that each
+// side variant sets every edge exactly once - two classes targeting the same padding
+// property at the same breakpoint would otherwise race in Tailwind's generated stylesheet.
+// The anchored edge(s) - the ones that actually touch a physical screen edge for that
+// side - get safe-area-aware padding; internal edges keep the original 1.5rem (p-6).
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed z-50 gap-4 bg-background shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
   {
     variants: {
       side: {
-        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        top: "inset-x-0 top-0 border-b pt-[max(1.5rem,env(safe-area-inset-top))] pb-6 pl-[max(1.5rem,env(safe-area-inset-left))] pr-[max(1.5rem,env(safe-area-inset-right))] data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
-          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          "inset-x-0 bottom-0 border-t pt-6 pb-[max(1.5rem,env(safe-area-inset-bottom))] pl-[max(1.5rem,env(safe-area-inset-left))] pr-[max(1.5rem,env(safe-area-inset-right))] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r pt-[max(1.5rem,env(safe-area-inset-top))] pb-[max(1.5rem,env(safe-area-inset-bottom))] pl-[max(1.5rem,env(safe-area-inset-left))] pr-6 data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-3/4  border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-3/4 border-l pt-[max(1.5rem,env(safe-area-inset-top))] pb-[max(1.5rem,env(safe-area-inset-bottom))] pl-6 pr-[max(1.5rem,env(safe-area-inset-right))] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
     },
     defaultVariants: {
@@ -51,36 +56,28 @@ interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
   VariantProps<typeof sheetVariants> { }
 
-// Sides that touch the top/bottom of the viewport (inset-y-0) need extra clearance for
-// the status bar / gesture bar on top of their normal p-6 padding; "top"/"bottom" sheets
-// only need it on the edge they're anchored to.
-const SIDE_SAFE_AREA_STYLE: Record<NonNullable<VariantProps<typeof sheetVariants>["side"]>, React.CSSProperties> = {
-  top: { paddingTop: "max(1.5rem, env(safe-area-inset-top))" },
-  bottom: { paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))" },
-  left: {
-    paddingTop: "max(1.5rem, env(safe-area-inset-top))",
-    paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))",
-  },
-  right: {
-    paddingTop: "max(1.5rem, env(safe-area-inset-top))",
-    paddingBottom: "max(1.5rem, env(safe-area-inset-bottom))",
-  },
+// Position of the absolute close button, per side: only the edges that are actually
+// anchored to a physical screen edge for that side need safe-area-aware offsets.
+const CLOSE_BUTTON_POSITION_CLASS: Record<NonNullable<VariantProps<typeof sheetVariants>["side"]>, string> = {
+  top: "right-[max(1rem,env(safe-area-inset-right))] top-[max(1rem,env(safe-area-inset-top))]",
+  bottom: "right-[max(1rem,env(safe-area-inset-right))] top-4",
+  left: "right-4 top-[max(1rem,env(safe-area-inset-top))]",
+  right: "right-[max(1rem,env(safe-area-inset-right))] top-[max(1rem,env(safe-area-inset-top))]",
 }
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
->(({ side = "right", className, children, style, ...props }, ref) => (
+>(({ side = "right", className, children, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
     <SheetPrimitive.Content
       ref={ref}
       className={cn(sheetVariants({ side }), className)}
-      style={{ ...SIDE_SAFE_AREA_STYLE[side ?? "right"], ...style }}
       {...props}
     >
       {children}
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      <SheetPrimitive.Close className={cn("absolute rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary", CLOSE_BUTTON_POSITION_CLASS[side ?? "right"])}>
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>

--- a/src/contexts/ThermalPrinterContext.tsx
+++ b/src/contexts/ThermalPrinterContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useCallback, useEffect, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
 import { toast } from 'sonner';
 import { 
   connectThermalPrinter,
@@ -12,7 +12,7 @@ interface ThermalPrinterContextType {
   isConnecting: boolean;
   lastError: string | null;
   connect: () => Promise<void>;
-  disconnect: () => void;
+  disconnect: () => Promise<void>;
   clearError: () => void;
 }
 
@@ -28,34 +28,6 @@ export const ThermalPrinterProvider: React.FC<ThermalPrinterProviderProps> = ({ 
   const [connectionStatus, setConnectionStatus] = useState<'disconnected' | 'connected' | 'error'>('disconnected');
   const [lastError, setLastError] = useState<string | null>(null);
 
-  // Monitor connection status
-  useEffect(() => {
-    if (printerConnection?.server?.connected) {
-      setConnectionStatus('connected');
-    } else if (printerConnection) {
-      // Connection object exists but server is disconnected
-      setConnectionStatus('disconnected');
-      setPrinterConnection(null);
-    }
-  }, [printerConnection]);
-
-  // Listen for Bluetooth device disconnection events
-  useEffect(() => {
-    if (printerConnection?.device) {
-      const handleDisconnect = () => {
-        setPrinterConnection(null);
-        setConnectionStatus('disconnected');
-        toast.info('🔌 Thermal printer disconnected');
-      };
-
-      printerConnection.device.addEventListener('gattserverdisconnected', handleDisconnect);
-
-      return () => {
-        printerConnection.device.removeEventListener('gattserverdisconnected', handleDisconnect);
-      };
-    }
-  }, [printerConnection]);
-
   const connect = useCallback(async () => {
     if (isConnecting || connectionStatus === 'connected') {
       return;
@@ -65,7 +37,11 @@ export const ThermalPrinterProvider: React.FC<ThermalPrinterProviderProps> = ({ 
     setLastError(null);
 
     try {
-      const connection = await connectThermalPrinter();
+      const connection = await connectThermalPrinter((disconnectedDeviceId) => {
+        setPrinterConnection((current) => (current?.deviceId === disconnectedDeviceId ? null : current));
+        setConnectionStatus((current) => (current === 'connected' ? 'disconnected' : current));
+        toast.info('🔌 Thermal printer disconnected');
+      });
       setPrinterConnection(connection);
       setConnectionStatus('connected');
       toast.success('✅ Connected to thermal printer!');
@@ -80,9 +56,9 @@ export const ThermalPrinterProvider: React.FC<ThermalPrinterProviderProps> = ({ 
     }
   }, [isConnecting, connectionStatus]);
 
-  const disconnect = useCallback(() => {
+  const disconnect = useCallback(async () => {
     if (printerConnection) {
-      disconnectThermalPrinter(printerConnection);
+      await disconnectThermalPrinter(printerConnection);
       setPrinterConnection(null);
       setConnectionStatus('disconnected');
       toast.success('🔌 Disconnected from thermal printer');

--- a/src/hooks/useAndroidBackButton.ts
+++ b/src/hooks/useAndroidBackButton.ts
@@ -1,0 +1,38 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { App } from '@capacitor/app';
+import { Capacitor } from '@capacitor/core';
+
+/**
+ * Wires the Android hardware Back button into the app.
+ * If a Radix dialog/sheet/popover is open, Back closes it first (Radix already
+ * closes on Escape, so we just replay that key instead of tracking every dialog's
+ * open state ourselves). Otherwise it goes back in-app, or exits on the root screen.
+ */
+export const useAndroidBackButton = (): void => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) {
+      return;
+    }
+
+    const listenerPromise = App.addListener('backButton', ({ canGoBack }) => {
+      const openDialog = document.querySelector('[role="dialog"], [role="alertdialog"]');
+      if (openDialog) {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+        return;
+      }
+
+      if (canGoBack) {
+        navigate(-1);
+      } else {
+        App.exitApp();
+      }
+    });
+
+    return () => {
+      listenerPromise.then((listener) => listener.remove());
+    };
+  }, [navigate]);
+};

--- a/src/hooks/useHideNativeSplashScreen.ts
+++ b/src/hooks/useHideNativeSplashScreen.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { Capacitor } from '@capacitor/core';
+import { SplashScreen } from '@capacitor/splash-screen';
+
+/**
+ * Hides the native splash screen after the app's first commit. capacitor.config.ts sets
+ * launchAutoHide: false so this is the only thing that hides it - calling SplashScreen.hide()
+ * from main.tsx synchronously after root.render() would race React's actual paint, since
+ * render() doesn't flush the DOM (or reflect on screen) synchronously.
+ */
+export const useHideNativeSplashScreen = (): void => {
+  useEffect(() => {
+    if (!Capacitor.isNativePlatform()) {
+      return;
+    }
+
+    SplashScreen.hide().catch((error) => {
+      console.error('Failed to hide native splash screen:', error);
+    });
+  }, []);
+};

--- a/src/hooks/useMobileBottomNavItems.ts
+++ b/src/hooks/useMobileBottomNavItems.ts
@@ -1,0 +1,57 @@
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Home as HomeIcon, Plus, TrendingUp, History, Building2 } from 'lucide-react';
+import { useStore } from '@/contexts/StoreContext';
+import { BottomNavItem } from '@/components/layout/MobileBottomNav';
+
+/**
+ * Builds the shared bottom-nav item set used across every screen: Beranda, Buat Pesanan,
+ * Laporan (owner) / Riwayat (staff), and Toko (owner-only).
+ */
+export const useMobileBottomNavItems = (): BottomNavItem[] => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { isOwner } = useStore();
+
+  const items: Array<BottomNavItem | null> = [
+    {
+      id: 'home',
+      title: 'Beranda',
+      icon: HomeIcon,
+      active: location.pathname === '/home',
+      onClick: () => navigate('/home'),
+    },
+    {
+      id: 'orders',
+      title: 'Buat Pesanan',
+      icon: Plus,
+      active: location.pathname === '/pos',
+      onClick: () => navigate('/pos'),
+    },
+    isOwner
+      ? {
+          id: 'reports',
+          title: 'Laporan',
+          icon: TrendingUp,
+          active: location.pathname === '/revenue-report',
+          onClick: () => navigate('/revenue-report'),
+        }
+      : {
+          id: 'reports',
+          title: 'Riwayat',
+          icon: History,
+          active: location.pathname === '/order-history',
+          onClick: () => navigate('/order-history'),
+        },
+    isOwner
+      ? {
+          id: 'stores',
+          title: 'Toko',
+          icon: Building2,
+          active: location.pathname === '/stores',
+          onClick: () => navigate('/stores'),
+        }
+      : null,
+  ];
+
+  return items.filter((item): item is BottomNavItem => item !== null);
+};

--- a/src/hooks/useMobileBottomNavItems.ts
+++ b/src/hooks/useMobileBottomNavItems.ts
@@ -1,7 +1,7 @@
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Home as HomeIcon, Plus, TrendingUp, History, Building2 } from 'lucide-react';
-import { useStore } from '@/contexts/StoreContext';
 import { BottomNavItem } from '@/components/layout/MobileBottomNav';
+import { useStore } from '@/contexts/StoreContext';
 
 /**
  * Builds the shared bottom-nav item set used across every screen: Beranda, Buat Pesanan,

--- a/src/hooks/usePWAInstall.ts
+++ b/src/hooks/usePWAInstall.ts
@@ -13,7 +13,8 @@ interface BeforeInstallPromptEvent extends Event {
 export const usePWAInstall = () => {
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [isInstallable, setIsInstallable] = useState(false);
-  const [isInstalled, setIsInstalled] = useState(false);
+  // Already installed by definition inside the native app shell.
+  const [isInstalled, setIsInstalled] = useState(() => Capacitor.isNativePlatform());
 
   useEffect(() => {
     // Already installed by definition inside the native app shell - the browser-only
@@ -63,6 +64,10 @@ export const usePWAInstall = () => {
   }, []);
 
   const installPWA = async () => {
+    if (Capacitor.isNativePlatform()) {
+      return;
+    }
+
     if (!deferredPrompt) {
       // For iOS Safari, show instructions
       const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);

--- a/src/hooks/usePWAInstall.ts
+++ b/src/hooks/usePWAInstall.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { Capacitor } from '@capacitor/core';
 
 interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[];
@@ -15,6 +16,12 @@ export const usePWAInstall = () => {
   const [isInstalled, setIsInstalled] = useState(false);
 
   useEffect(() => {
+    // Already installed by definition inside the native app shell - the browser-only
+    // beforeinstallprompt/appinstalled flow below doesn't apply there.
+    if (Capacitor.isNativePlatform()) {
+      return;
+    }
+
     const handleBeforeInstallPrompt = (e: BeforeInstallPromptEvent) => {
       // Prevent the mini-infobar from appearing on mobile
       e.preventDefault();

--- a/src/lib/printUtils.ts
+++ b/src/lib/printUtils.ts
@@ -384,6 +384,11 @@ export const isBluetoothSupported = (): boolean => {
  * Find a writable characteristic among a device's discovered services, preferring the
  * known thermal-printer service UUIDs but falling back to any writable characteristic
  * if none of those are present.
+ *
+ * Note: the "fall back to any service" path only does anything useful on native platforms.
+ * On web, requestDevice's optionalServices (set to THERMAL_PRINTER_SERVICES) is a hard
+ * allowlist enforced by the Web Bluetooth API itself - getServices() can never return a
+ * service outside that list there, so `services` is already equivalent to `knownServices`.
  */
 const findWritableCharacteristic = async (
   deviceId: string,
@@ -409,8 +414,8 @@ const findWritableCharacteristic = async (
           await BleClient.write(deviceId, service.uuid, characteristic.uuid, testData);
         }
         return { serviceUuid: service.uuid, characteristicUuid: characteristic.uuid, useWithoutResponse };
-      } catch {
-        // Not actually writable in practice, try the next candidate
+      } catch (error) {
+        console.warn(`Characteristic ${characteristic.uuid} (service ${service.uuid}) rejected the test write:`, error);
       }
     }
   }
@@ -435,7 +440,7 @@ export const isThermerAppAvailable = (): boolean => {
  */
 export const connectThermalPrinter = async (
   onDisconnect?: (deviceId: string) => void
-): Promise<ThermalPrinterConnection | null> => {
+): Promise<ThermalPrinterConnection> => {
   if (!isBluetoothSupported()) {
     throw new Error('Bluetooth is not supported on this device');
   }
@@ -449,9 +454,25 @@ export const connectThermalPrinter = async (
       optionalServices: THERMAL_PRINTER_SERVICES,
     });
 
-    await BleClient.connect(device.deviceId, onDisconnect);
+    // Don't forward onDisconnect until setup actually succeeds below - otherwise the
+    // cleanup disconnect() in the !writable branch would fire it, showing a spurious
+    // "printer disconnected" toast right before the real "connection failed" one.
+    let setupComplete = false;
+    await BleClient.connect(device.deviceId, (disconnectedDeviceId) => {
+      if (setupComplete) {
+        onDisconnect?.(disconnectedDeviceId);
+      }
+    });
 
-    const services = await BleClient.getServices(device.deviceId);
+    let services = await BleClient.getServices(device.deviceId);
+    const hasDiscoveredCharacteristics = services.some(service => service.characteristics.length > 0);
+    // Some Android devices resolve `connect` before GATT service discovery has actually
+    // finished, leaving getServices() empty - force a fresh discovery and retry once.
+    if (!hasDiscoveredCharacteristics && Capacitor.isNativePlatform()) {
+      await BleClient.discoverServices(device.deviceId);
+      services = await BleClient.getServices(device.deviceId);
+    }
+
     const writable = await findWritableCharacteristic(device.deviceId, services);
 
     if (!writable) {
@@ -459,6 +480,7 @@ export const connectThermalPrinter = async (
       throw new Error(`No compatible thermal printer service/characteristic found for ${device.name || 'this device'}. Please ensure the printer is in pairing mode and try again.`);
     }
 
+    setupComplete = true;
     return {
       deviceId: device.deviceId,
       deviceName: device.name,
@@ -863,8 +885,20 @@ export const printToThermalPrinter = async (
       ...options
     });
 
-    // Split data into smaller chunks to be more conservative with Bluetooth
-    const CHUNK_SIZE = 128;
+    // Native BLE writes are capped at the negotiated MTU minus 3 bytes of ATT overhead -
+    // a fixed 128-byte chunk can exceed that (default MTU is often only 23 bytes) and every
+    // write then fails. getMtu isn't available on web, where the plugin's Web Bluetooth
+    // backing handles this differently, so keep the previous fixed size there.
+    let CHUNK_SIZE = 128;
+    if (Capacitor.isNativePlatform()) {
+      try {
+        const mtu = await BleClient.getMtu(connection.deviceId);
+        CHUNK_SIZE = Math.max(20, mtu - 3);
+      } catch (error) {
+        console.warn('Failed to read negotiated MTU, falling back to a conservative chunk size:', error);
+        CHUNK_SIZE = 20;
+      }
+    }
     const chunks: Uint8Array[] = [];
 
     for (let i = 0; i < printData.byteLength; i += CHUNK_SIZE) {

--- a/src/lib/printUtils.ts
+++ b/src/lib/printUtils.ts
@@ -1,52 +1,6 @@
-// Type declarations for Web Bluetooth API
-declare global {
-  interface Navigator {
-    bluetooth?: {
-      requestDevice(options?: RequestDeviceOptions): Promise<BluetoothDevice>;
-    };
-  }
-  
-  interface BluetoothDevice {
-    id: string;
-    name?: string;
-    gatt?: BluetoothRemoteGATTServer;
-    addEventListener(type: string, listener: EventListener): void;
-    removeEventListener(type: string, listener: EventListener): void;
-  }
-  
-  interface BluetoothRemoteGATTServer {
-    connected: boolean;
-    connect(): Promise<BluetoothRemoteGATTServer>;
-    disconnect(): void;
-    getPrimaryService(service: BluetoothServiceUUID): Promise<BluetoothRemoteGATTService>;
-  }
-  
-  interface BluetoothRemoteGATTService {
-    getCharacteristic(characteristic: BluetoothServiceUUID): Promise<BluetoothRemoteGATTCharacteristic>;
-  }
-  
-  interface BluetoothRemoteGATTCharacteristic {
-    writeValue(value: BufferSource): Promise<void>;
-    writeValueWithResponse(value: BufferSource): Promise<void>;
-    writeValueWithoutResponse(value: BufferSource): Promise<void>;
-  }
-  
-  interface RequestDeviceOptions {
-    filters?: BluetoothLEScanFilter[];
-    acceptAllDevices?: boolean;
-    optionalServices?: BluetoothServiceUUID[];
-  }
-  
-  interface BluetoothLEScanFilter {
-    services?: BluetoothServiceUUID[];
-    name?: string;
-    namePrefix?: string;
-  }
-  
-  type BluetoothServiceUUID = string | number;
-}
-
 import { supabase } from '@/integrations/supabase/client';
+import { BleClient, BleService } from '@capacitor-community/bluetooth-le';
+import { Capacitor } from '@capacitor/core';
 
 // Constants
 const IFRAME_RENDER_WAIT_MS = 1000;
@@ -117,10 +71,11 @@ interface PrintOptions {
 }
 
 export interface ThermalPrinterConnection {
-  device: BluetoothDevice;
-  server: BluetoothRemoteGATTServer;
-  service: BluetoothRemoteGATTService;
-  characteristic: BluetoothRemoteGATTCharacteristic;
+  deviceId: string;
+  deviceName?: string;
+  serviceUuid: string;
+  characteristicUuid: string;
+  useWithoutResponse: boolean;
 }
 
 interface ThermalPrintOptions {
@@ -155,6 +110,13 @@ const combineBytes = (...arrays: Uint8Array[]): Uint8Array => {
     offset += arr.length;
   }
   return result;
+};
+
+/**
+ * Wrap a Uint8Array in a DataView, as required by @capacitor-community/bluetooth-le's write calls
+ */
+const uint8ArrayToDataView = (bytes: Uint8Array): DataView => {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
 };
 
 /**
@@ -412,10 +374,48 @@ export const generateReceiptPDFFromUrl = async (
 };
 
 /**
- * Check if Web Bluetooth is supported
+ * Check if Bluetooth Low Energy is supported: native (Android/iOS via Capacitor) or Web Bluetooth in-browser
  */
 export const isBluetoothSupported = (): boolean => {
-  return 'bluetooth' in navigator;
+  return Capacitor.isNativePlatform() || 'bluetooth' in navigator;
+};
+
+/**
+ * Find a writable characteristic among a device's discovered services, preferring the
+ * known thermal-printer service UUIDs but falling back to any writable characteristic
+ * if none of those are present.
+ */
+const findWritableCharacteristic = async (
+  deviceId: string,
+  services: BleService[]
+): Promise<{ serviceUuid: string; characteristicUuid: string; useWithoutResponse: boolean } | null> => {
+  const knownServices = services.filter(service =>
+    THERMAL_PRINTER_SERVICES.includes(service.uuid.toLowerCase())
+  );
+  const candidateServices = knownServices.length > 0 ? knownServices : services;
+
+  for (const service of candidateServices) {
+    for (const characteristic of service.characteristics) {
+      const useWithoutResponse = !characteristic.properties.write && characteristic.properties.writeWithoutResponse;
+      if (!characteristic.properties.write && !useWithoutResponse) {
+        continue;
+      }
+
+      try {
+        const testData = uint8ArrayToDataView(new Uint8Array([ESC, 0x40])); // ESC @ (initialize printer)
+        if (useWithoutResponse) {
+          await BleClient.writeWithoutResponse(deviceId, service.uuid, characteristic.uuid, testData);
+        } else {
+          await BleClient.write(deviceId, service.uuid, characteristic.uuid, testData);
+        }
+        return { serviceUuid: service.uuid, characteristicUuid: characteristic.uuid, useWithoutResponse };
+      } catch {
+        // Not actually writable in practice, try the next candidate
+      }
+    }
+  }
+
+  return null;
 };
 
 /**
@@ -427,104 +427,44 @@ export const isThermerAppAvailable = (): boolean => {
 };
 
 /**
- * Connect to thermal printer via Bluetooth
+ * Connect to thermal printer via Bluetooth Low Energy.
+ * Works both inside the native Android/iOS app (via Capacitor's native BLE stack) and
+ * in a regular browser (the plugin falls back to the Web Bluetooth API on web).
+ *
+ * @param onDisconnect Optional callback fired with the device's ID when it disconnects unexpectedly
  */
-export const connectThermalPrinter = async (): Promise<ThermalPrinterConnection | null> => {
+export const connectThermalPrinter = async (
+  onDisconnect?: (deviceId: string) => void
+): Promise<ThermalPrinterConnection | null> => {
   if (!isBluetoothSupported()) {
-    throw new Error('Bluetooth is not supported in this browser');
+    throw new Error('Bluetooth is not supported on this device');
   }
 
   try {
-    
-    // Request thermal printer device with specific filters for MP-80M and similar printers
-    const device = await navigator.bluetooth!.requestDevice({
-      filters: [
-        // Filter by device name patterns (common thermal printer names)
-        { namePrefix: 'RPP' },
-        { namePrefix: 'MP-' },
-        { namePrefix: 'PRINTER' },
-        { namePrefix: 'POS' },
-        { namePrefix: 'THERMAL' },
-        { name: 'RPP02N' }, // Your specific printer
-        // Filter by services
-        { services: ['000018f0-0000-1000-8000-00805f9b34fb'] },
-        { services: ['00001101-0000-1000-8000-00805f9b34fb'] },
-        { services: ['0000ff00-0000-1000-8000-00805f9b34fb'] },
-        { services: ['0000fee0-0000-1000-8000-00805f9b34fb'] },
-        { services: ['49535343-fe7d-4ae5-8fa9-9fafd205e455'] },
-        { services: ['6e400001-b5a3-f393-e0a9-e50e24dcca9e'] }
-      ],
-      optionalServices: [...THERMAL_PRINTER_SERVICES, ...THERMAL_PRINTER_CHARACTERISTICS]
+    await BleClient.initialize({ androidNeverForLocation: true });
+
+    // Let the user pick from all nearby BLE devices - printer name/branding varies too much
+    // across vendors to reliably pre-filter, so we discover the write characteristic afterward instead.
+    const device = await BleClient.requestDevice({
+      optionalServices: THERMAL_PRINTER_SERVICES,
     });
 
+    await BleClient.connect(device.deviceId, onDisconnect);
 
-    if (!device.gatt) {
-      throw new Error('Device does not support GATT');
+    const services = await BleClient.getServices(device.deviceId);
+    const writable = await findWritableCharacteristic(device.deviceId, services);
+
+    if (!writable) {
+      await BleClient.disconnect(device.deviceId);
+      throw new Error(`No compatible thermal printer service/characteristic found for ${device.name || 'this device'}. Please ensure the printer is in pairing mode and try again.`);
     }
 
-    // Connect to the device
-    const server = await device.gatt.connect();
-    
-    
-    // Try to find a compatible service from our known list first
-    let service: BluetoothRemoteGATTService | null = null;
-    let characteristic: BluetoothRemoteGATTCharacteristic | null = null;
-    
-    for (const serviceUuid of THERMAL_PRINTER_SERVICES) {
-      try {
-        service = await server.getPrimaryService(serviceUuid);
-        
-        // Get all characteristics for this service
-        try {
-          const characteristics = await (service as any).getCharacteristics();
-        } catch (charListError) {
-        }
-        
-        // Try to find a compatible characteristic
-        for (const charUuid of THERMAL_PRINTER_CHARACTERISTICS) {
-          try {
-            characteristic = await service.getCharacteristic(charUuid);
-            
-            // Test if we can write to this characteristic
-            try {
-              // Try a small test write to check permissions
-              const testData = new Uint8Array([0x1B, 0x40]); // ESC @ (initialize printer)
-              await characteristic.writeValue(testData);
-              break;
-            } catch (writeError) {
-              try {
-                // Try writeValueWithoutResponse if available
-                if ('writeValueWithoutResponse' in characteristic) {
-                  const testData = new Uint8Array([0x1B, 0x40]);
-                  await (characteristic as any).writeValueWithoutResponse(testData);
-                  break;
-                } else {
-                }
-              } catch (writeWithoutResponseError) {
-                characteristic = null;
-              }
-            }
-          } catch (charError) {
-          }
-        }
-        
-        if (characteristic) break;
-      } catch (serviceError) {
-      }
-    }
-
-    // If no known service worked, log error with helpful information
-    if (!service || !characteristic) {
-      device.gatt.disconnect();
-      throw new Error(`No compatible thermal printer service/characteristic found for ${device.name || 'MP-80M'}. Please ensure the printer is in pairing mode and try again.`);
-    }
-
-    
     return {
-      device,
-      server,
-      service,
-      characteristic
+      deviceId: device.deviceId,
+      deviceName: device.name,
+      serviceUuid: writable.serviceUuid,
+      characteristicUuid: writable.characteristicUuid,
+      useWithoutResponse: writable.useWithoutResponse,
     };
   } catch (error) {
     console.error('Failed to connect to thermal printer:', error);
@@ -535,11 +475,9 @@ export const connectThermalPrinter = async (): Promise<ThermalPrinterConnection 
 /**
  * Disconnect from thermal printer
  */
-export const disconnectThermalPrinter = (connection: ThermalPrinterConnection): void => {
+export const disconnectThermalPrinter = async (connection: ThermalPrinterConnection): Promise<void> => {
   try {
-    if (connection.server.connected) {
-      connection.server.disconnect();
-    }
+    await BleClient.disconnect(connection.deviceId);
   } catch (error) {
     console.error('Error disconnecting from thermal printer:', error);
   }
@@ -918,15 +856,6 @@ export const printToThermalPrinter = async (
   }
 
   try {
-    // Validate connection state before printing
-    if (!connection.server?.connected) {
-      throw new Error('Bluetooth connection is not active. Please reconnect to the printer.');
-    }
-
-    if (!connection.characteristic) {
-      throw new Error('Printer characteristic is not available. Please reconnect to the printer.');
-    }
-
     const printData = formatReceiptForThermal(receiptData, {
       paperWidth: 32,
       cutPaper: true,
@@ -934,66 +863,40 @@ export const printToThermalPrinter = async (
       ...options
     });
 
-    
     // Split data into smaller chunks to be more conservative with Bluetooth
-    const CHUNK_SIZE = 128; // Reduced from 512 to be more conservative
-    const chunks = [];
-    
+    const CHUNK_SIZE = 128;
+    const chunks: Uint8Array[] = [];
+
     for (let i = 0; i < printData.byteLength; i += CHUNK_SIZE) {
-      const chunk = printData.slice(i, i + CHUNK_SIZE);
-      chunks.push(chunk);
+      chunks.push(printData.slice(i, i + CHUNK_SIZE));
     }
-    
-    
-    // Send chunks with longer delays to ensure printer can process
+
+    // Send chunks with delays to ensure the printer can process each one
     for (let i = 0; i < chunks.length; i++) {
-      const chunk = chunks[i];
-      
+      const chunk = uint8ArrayToDataView(chunks[i]);
+
       try {
-        // Check connection before each chunk
-        if (!connection.server?.connected) {
-          throw new Error('Connection lost during printing. Please reconnect and try again.');
+        if (connection.useWithoutResponse) {
+          await BleClient.writeWithoutResponse(connection.deviceId, connection.serviceUuid, connection.characteristicUuid, chunk);
+        } else {
+          await BleClient.write(connection.deviceId, connection.serviceUuid, connection.characteristicUuid, chunk);
         }
-        
-        // Try writeValue first, then writeValueWithoutResponse if it fails
-        try {
-          await connection.characteristic.writeValue(chunk);
-        } catch (writeError) {
-          if ('writeValueWithoutResponse' in connection.characteristic) {
-            await (connection.characteristic as any).writeValueWithoutResponse(chunk);
-          } else {
-            throw writeError;
-          }
-        }
-        
-        // Longer delay between chunks to prevent overwhelming the printer
+
         if (i < chunks.length - 1) {
-          await new Promise(resolve => setTimeout(resolve, 200)); // Increased from 100ms to 200ms
+          await new Promise(resolve => setTimeout(resolve, 200));
         }
       } catch (chunkError) {
-        console.error(`❌ Error sending chunk ${i + 1}:`, chunkError);
-        
-        // If it's a GATT error, provide specific guidance
-        if (chunkError.message?.includes('GATT') || chunkError.message?.includes('not permitted')) {
-          throw new Error('Printer connection error. Please disconnect and reconnect to the thermal printer, then try again.');
-        }
-        
-        throw chunkError;
+        console.error(`Error sending chunk ${i + 1}:`, chunkError);
+        throw new Error('Printer connection error. Please disconnect and reconnect to the thermal printer, then try again.');
       }
     }
-    
+
     // Add a final delay to ensure all data is processed by the printer
     await new Promise(resolve => setTimeout(resolve, 500));
-    
+
   } catch (error) {
     console.error('Error printing to thermal printer:', error);
-    
-    // Provide more specific error messages for common issues
-    if (error.message?.includes('GATT') || error.message?.includes('not permitted')) {
-      throw new Error('Printer connection error. Please disconnect and reconnect to the thermal printer, then try again.');
-    }
-    
-    throw new Error(`Failed to print to thermal printer: ${error.message}`);
+    throw error instanceof Error ? error : new Error('Failed to print to thermal printer');
   }
 };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,6 @@ import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/react";
 import { Capacitor } from "@capacitor/core";
 import { StatusBar, Style } from "@capacitor/status-bar";
-import { SplashScreen } from "@capacitor/splash-screen";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
@@ -17,12 +16,16 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 );
 
 // Native-only startup: let content sit under the status bar (safe-area insets in the
-// CSS make room for it) with dark icons for this app's light theme, then swap the
-// native splash screen for the real UI now that it's rendered.
+// CSS make room for it) with dark icons for this app's light theme. The native splash
+// screen is hidden from inside <App> instead, after its first commit - hiding it here
+// would race root.render(), which doesn't paint synchronously.
 if (Capacitor.isNativePlatform()) {
-  StatusBar.setOverlaysWebView({ overlay: true }).catch(() => {});
-  StatusBar.setStyle({ style: Style.Light }).catch(() => {});
-  SplashScreen.hide().catch(() => {});
+  StatusBar.setOverlaysWebView({ overlay: true }).catch((error) => {
+    console.error('Failed to set status bar overlay mode:', error);
+  });
+  StatusBar.setStyle({ style: Style.Light }).catch((error) => {
+    console.error('Failed to set status bar style:', error);
+  });
 }
 
 // Register service worker for PWA functionality

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,6 +4,9 @@ import App from "./App.tsx";
 import "./index.css";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/react";
+import { Capacitor } from "@capacitor/core";
+import { StatusBar, Style } from "@capacitor/status-bar";
+import { SplashScreen } from "@capacitor/splash-screen";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
@@ -12,6 +15,15 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <SpeedInsights />
   </React.StrictMode>,
 );
+
+// Native-only startup: let content sit under the status bar (safe-area insets in the
+// CSS make room for it) with dark icons for this app's light theme, then swap the
+// native splash screen for the real UI now that it's rendered.
+if (Capacitor.isNativePlatform()) {
+  StatusBar.setOverlaysWebView({ overlay: true }).catch(() => {});
+  StatusBar.setStyle({ style: Style.Light }).catch(() => {});
+  SplashScreen.hide().catch(() => {});
+}
 
 // Register service worker for PWA functionality
 if ('serviceWorker' in navigator) {

--- a/src/pages/CustomersPage.tsx
+++ b/src/pages/CustomersPage.tsx
@@ -281,7 +281,7 @@ export const CustomersPage: React.FC = () => {
 
     return (
       <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
-        <div className="text-sm text-gray-500 text-center sm:text-left">
+        <div className="text-sm text-muted-foreground text-center sm:text-left">
           Showing {((currentPage - 1) * ITEMS_PER_PAGE) + 1} to{' '}
           {Math.min(currentPage * ITEMS_PER_PAGE, pagination.totalCount)} of{' '}
           {pagination.totalCount} customers
@@ -346,7 +346,7 @@ export const CustomersPage: React.FC = () => {
   if (!currentStore) {
     return (
       <div className="flex items-center justify-center h-64">
-        <p className="text-gray-500">Please select a store to view customers</p>
+        <p className="text-muted-foreground">Please select a store to view customers</p>
       </div>
     );
   }
@@ -365,13 +365,13 @@ export const CustomersPage: React.FC = () => {
             <ArrowLeft className="h-4 w-4" />
           </Button>
           <div>
-            <h1 className="text-xl sm:text-2xl font-bold text-gray-900">Customers</h1>
-            <p className="text-sm sm:text-base text-gray-600">Manage your customer database</p>
+            <h1 className="text-xl sm:text-2xl font-bold text-foreground">Customers</h1>
+            <p className="text-sm sm:text-base text-muted-foreground">Manage your customer database</p>
           </div>
         </div>
         <AddCustomerDialog
           trigger={
-            <Button className="bg-blue-600 hover:bg-blue-700 w-full sm:w-auto">
+            <Button className="w-full sm:w-auto">
               <Plus className="h-4 w-4 mr-2" />
               Add Customer
             </Button>
@@ -417,7 +417,7 @@ export const CustomersPage: React.FC = () => {
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
             <div className="flex flex-col sm:flex-row sm:items-center gap-3 flex-1">
               <div className="relative flex-1 sm:max-w-sm">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                 <Input
                   placeholder="Search customers..."
                   value={searchQuery}
@@ -441,9 +441,9 @@ export const CustomersPage: React.FC = () => {
             </div>
           ) : customers.length === 0 ? (
             <div className="text-center py-8">
-              <Users className="h-12 w-12 mx-auto text-gray-400 mb-4" />
-              <h3 className="text-lg font-medium text-gray-900 mb-2">No customers found</h3>
-              <p className="text-gray-600">
+              <Users className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+              <h3 className="text-lg font-medium text-foreground mb-2">No customers found</h3>
+              <p className="text-muted-foreground">
                 {searchQuery ? 'Try adjusting your search terms' : 'Get started by adding your first customer'}
               </p>
             </div>
@@ -463,28 +463,28 @@ export const CustomersPage: React.FC = () => {
                   {customers.map((customer) => (
                     <TableRow 
                       key={customer.id}
-                      className="cursor-pointer hover:bg-gray-50"
+                      className="cursor-pointer hover:bg-muted/50"
                       onClick={() => handleCustomerClick(customer)}
                     >
                       <TableCell>
                         <div>
                           <div className="font-medium">{customer.name}</div>
-                          <div className="text-sm text-gray-500 md:hidden flex items-center gap-1">
+                          <div className="text-sm text-muted-foreground md:hidden flex items-center gap-1">
                             <Phone className="h-3 w-3" />
                             {customer.phone}
                           </div>
                           {customer.email && (
-                            <div className="text-sm text-gray-500 hidden md:block">{customer.email}</div>
+                            <div className="text-sm text-muted-foreground hidden md:block">{customer.email}</div>
                           )}
                         </div>
                       </TableCell>
                       <TableCell className="hidden md:table-cell">
                         <div className="flex items-center space-x-2">
-                          <Phone className="h-4 w-4 text-gray-400" />
+                          <Phone className="h-4 w-4 text-muted-foreground" />
                           <span>{customer.phone}</span>
                         </div>
                         {customer.address && (
-                          <div className="flex items-center space-x-2 text-sm text-gray-500 mt-1">
+                          <div className="flex items-center space-x-2 text-sm text-muted-foreground mt-1">
                             <MapPin className="h-3 w-3" />
                             <span className="truncate max-w-[200px]">{customer.address}</span>
                           </div>
@@ -498,7 +498,7 @@ export const CustomersPage: React.FC = () => {
                           <CustomerPointsBadge customerPhone={customer.phone} />
                         </div>
                       </TableCell>
-                      <TableCell className="text-sm text-gray-500 hidden lg:table-cell">
+                      <TableCell className="text-sm text-muted-foreground hidden lg:table-cell">
                         {formatDate(customer.created_at)}
                       </TableCell>
                       <TableCell className="text-right">
@@ -537,7 +537,7 @@ export const CustomersPage: React.FC = () => {
                                 e.stopPropagation();
                                 handleDeleteClick(customer);
                               }}
-                              className="text-red-600"
+                              className="text-destructive"
                             >
                               <Trash2 className="h-4 w-4 mr-2" />
                               Delete
@@ -575,25 +575,25 @@ export const CustomersPage: React.FC = () => {
             <div className="space-y-4">
               <div>
                 <h3 className="font-medium text-lg">{selectedCustomer.name}</h3>
-                <p className="text-sm text-gray-500">Customer since {formatDate(selectedCustomer.created_at)}</p>
+                <p className="text-sm text-muted-foreground">Customer since {formatDate(selectedCustomer.created_at)}</p>
               </div>
 
               <div className="space-y-3">
                 <div className="flex items-center space-x-3">
-                  <Phone className="h-4 w-4 text-gray-400" />
+                  <Phone className="h-4 w-4 text-muted-foreground" />
                   <span>{selectedCustomer.phone}</span>
                 </div>
-                
+
                 {selectedCustomer.email && (
                   <div className="flex items-center space-x-3">
-                    <Mail className="h-4 w-4 text-gray-400" />
+                    <Mail className="h-4 w-4 text-muted-foreground" />
                     <span>{selectedCustomer.email}</span>
                   </div>
                 )}
-                
+
                 {selectedCustomer.address && (
                   <div className="flex items-start space-x-3">
-                    <MapPin className="h-4 w-4 text-gray-400 mt-0.5" />
+                    <MapPin className="h-4 w-4 text-muted-foreground mt-0.5" />
                     <span className="text-sm">{selectedCustomer.address}</span>
                   </div>
                 )}
@@ -661,9 +661,9 @@ export const CustomersPage: React.FC = () => {
           </AlertDialogHeader>
           <AlertDialogFooter className="flex-col sm:flex-row gap-2">
             <AlertDialogCancel className="mt-0">Cancel</AlertDialogCancel>
-            <AlertDialogAction 
+            <AlertDialogAction
               onClick={handleDeleteCustomer}
-              className="bg-red-600 hover:bg-red-700"
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
               Delete
             </AlertDialogAction>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -172,7 +172,9 @@ export const HomePage: React.FC = () => {
   // Grid excludes "new-order" - it's promoted to a full-width hero button instead.
   const gridActions = quickActions.filter((action) => action.id !== 'new-order');
 
-  const bottomNavItems = [
+  // Only used by the desktop fallback view below - the mobile view's bottom nav
+  // now comes from AppLayout (shared across every screen, not just Home).
+  const desktopBottomNavItems = [
     {
       id: 'home',
       title: 'Beranda',
@@ -230,7 +232,6 @@ export const HomePage: React.FC = () => {
         totalSteps={activation?.totalSteps ?? 1}
         onCreateOrder={() => navigate('/pos')}
         gridActions={gridActions}
-        bottomNavItems={bottomNavItems}
       />
     );
   }
@@ -390,7 +391,7 @@ export const HomePage: React.FC = () => {
       {/* Bottom Navigation Bar */}
       <div className="fixed bottom-0 left-0 right-0 bg-white border-t border-gray-200 shadow-lg">
         <div className={`flex justify-center gap-4 max-w-md mx-auto px-4`}>
-          {bottomNavItems.map((item) => (
+          {desktopBottomNavItems.map((item) => (
             <button
               key={item.id}
               onClick={item.onClick}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -80,7 +80,7 @@ export const Login: React.FC = () => {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+    <div className="min-h-screen flex items-center justify-center bg-background px-4">
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <CardTitle className="text-2xl font-bold">Smart Laundry POS</CardTitle>
@@ -110,7 +110,7 @@ export const Login: React.FC = () => {
                     })}
                   />
                   {loginForm.formState.errors.email && (
-                    <p className="text-sm text-red-500">{loginForm.formState.errors.email.message}</p>
+                    <p className="text-sm text-destructive">{loginForm.formState.errors.email.message}</p>
                   )}
                 </div>
 
@@ -138,14 +138,14 @@ export const Login: React.FC = () => {
                       onClick={() => setShowLoginPassword(!showLoginPassword)}
                     >
                       {showLoginPassword ? (
-                        <EyeOff className="h-4 w-4 text-gray-500" />
+                        <EyeOff className="h-4 w-4 text-muted-foreground" />
                       ) : (
-                        <Eye className="h-4 w-4 text-gray-500" />
+                        <Eye className="h-4 w-4 text-muted-foreground" />
                       )}
                     </Button>
                   </div>
                   {loginForm.formState.errors.password && (
-                    <p className="text-sm text-red-500">{loginForm.formState.errors.password.message}</p>
+                    <p className="text-sm text-destructive">{loginForm.formState.errors.password.message}</p>
                   )}
                 </div>
 
@@ -173,7 +173,7 @@ export const Login: React.FC = () => {
                     })}
                   />
                   {signUpForm.formState.errors.fullName && (
-                    <p className="text-sm text-red-500">{signUpForm.formState.errors.fullName.message}</p>
+                    <p className="text-sm text-destructive">{signUpForm.formState.errors.fullName.message}</p>
                   )}
                 </div>
 
@@ -192,7 +192,7 @@ export const Login: React.FC = () => {
                     })}
                   />
                   {signUpForm.formState.errors.email && (
-                    <p className="text-sm text-red-500">{signUpForm.formState.errors.email.message}</p>
+                    <p className="text-sm text-destructive">{signUpForm.formState.errors.email.message}</p>
                   )}
                 </div>
 
@@ -207,7 +207,7 @@ export const Login: React.FC = () => {
                     })}
                   />
                   {signUpForm.formState.errors.phone && (
-                    <p className="text-sm text-red-500">{signUpForm.formState.errors.phone.message}</p>
+                    <p className="text-sm text-destructive">{signUpForm.formState.errors.phone.message}</p>
                   )}
                 </div>
                 
@@ -235,14 +235,14 @@ export const Login: React.FC = () => {
                       onClick={() => setShowSignupPassword(!showSignupPassword)}
                     >
                       {showSignupPassword ? (
-                        <EyeOff className="h-4 w-4 text-gray-500" />
+                        <EyeOff className="h-4 w-4 text-muted-foreground" />
                       ) : (
-                        <Eye className="h-4 w-4 text-gray-500" />
+                        <Eye className="h-4 w-4 text-muted-foreground" />
                       )}
                     </Button>
                   </div>
                   {signUpForm.formState.errors.password && (
-                    <p className="text-sm text-red-500">{signUpForm.formState.errors.password.message}</p>
+                    <p className="text-sm text-destructive">{signUpForm.formState.errors.password.message}</p>
                   )}
                 </div>
 
@@ -257,7 +257,7 @@ export const Login: React.FC = () => {
                     })}
                   />
                   {signUpForm.formState.errors.storeName && (
-                    <p className="text-sm text-red-500">{signUpForm.formState.errors.storeName.message}</p>
+                    <p className="text-sm text-destructive">{signUpForm.formState.errors.storeName.message}</p>
                   )}
                 </div>
 
@@ -265,7 +265,7 @@ export const Login: React.FC = () => {
                   <CollapsibleTrigger asChild>
                     <button
                       type="button"
-                      className="flex w-full items-center justify-between rounded-md py-2 text-sm font-medium text-gray-600 hover:text-gray-900"
+                      className="flex w-full items-center justify-between rounded-md py-2 text-sm font-medium text-muted-foreground hover:text-foreground"
                     >
                       <span>Detail toko (opsional)</span>
                       <ChevronDown
@@ -293,7 +293,7 @@ export const Login: React.FC = () => {
                         {...signUpForm.register('storePhone')}
                       />
                     </div>
-                    <p className="text-xs text-gray-500">
+                    <p className="text-xs text-muted-foreground">
                       Bisa dilengkapi nanti di Pengaturan Toko.
                     </p>
                   </CollapsibleContent>
@@ -315,7 +315,7 @@ export const Login: React.FC = () => {
           <GoogleLoginButton />
         </CardContent>
         <CardFooter className="text-center">
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-muted-foreground">
             Akses aman ke sistem manajemen laundry Anda
           </p>
         </CardFooter>

--- a/src/pages/OrderHistoryOptimized.tsx
+++ b/src/pages/OrderHistoryOptimized.tsx
@@ -282,22 +282,22 @@ export const OrderHistory = () => {
 
   const getExecutionStatusColor = (status: string) => {
     switch (status) {
-      case 'completed': return 'bg-green-100 text-green-800';
-      case 'ready_for_pickup': return 'bg-emerald-100 text-emerald-800';
-      case 'in_progress': return 'bg-blue-100 text-blue-800';
-      case 'in_queue': return 'bg-yellow-100 text-yellow-800';
-      case 'cancelled': return 'bg-red-100 text-red-800';
-      default: return 'bg-gray-100 text-gray-800';
+      case 'completed': return 'bg-pos-success/10 text-pos-success border border-pos-success/30';
+      case 'ready_for_pickup': return 'bg-pos-warning/10 text-pos-warning border border-pos-warning/30';
+      case 'in_progress': return 'bg-pos-highlight/30 text-primary border border-primary/20';
+      case 'in_queue': return 'bg-pos-highlight/20 text-primary border border-pos-highlight/40';
+      case 'cancelled': return 'bg-destructive/10 text-destructive border border-destructive/30';
+      default: return 'bg-muted text-muted-foreground border border-border';
     }
   };
 
   const getPaymentStatusColor = (status: string) => {
     switch (status) {
-      case 'completed': return 'bg-green-100 text-green-800';
-      case 'down_payment': return 'bg-orange-100 text-orange-800';
-      case 'pending': return 'bg-yellow-100 text-yellow-800';
-      case 'refunded': return 'bg-red-100 text-red-800';
-      default: return 'bg-gray-100 text-gray-800';
+      case 'completed': return 'bg-pos-success/10 text-pos-success border border-pos-success/30';
+      case 'down_payment': return 'bg-pos-highlight/30 text-primary border border-primary/20';
+      case 'pending': return 'bg-pos-warning/10 text-pos-warning border border-pos-warning/30';
+      case 'refunded': return 'bg-destructive/10 text-destructive border border-destructive/30';
+      default: return 'bg-muted text-muted-foreground border border-border';
     }
   };
 
@@ -569,7 +569,7 @@ export const OrderHistory = () => {
                   <PopoverTrigger asChild>
                     <Button 
                       variant="outline" 
-                      className={`w-full sm:w-auto ${hasActiveFilters ? 'bg-blue-50 border-blue-200' : ''}`}
+                      className={`w-full sm:w-auto ${hasActiveFilters ? 'bg-muted border-primary/30' : ''}`}
                     >
                       <Filter className="h-4 w-4 mr-2" />
                       Filter

--- a/src/pages/ServiceManagement.tsx
+++ b/src/pages/ServiceManagement.tsx
@@ -211,13 +211,13 @@ const ServiceManagement = () => {
 
       {/* Error State */}
       {error && (
-        <Card className="border-red-200 bg-red-50">
+        <Card className="border-destructive/30 bg-destructive/5">
           <CardContent className="p-4">
             <div className="flex items-center space-x-2">
-              <AlertCircle className="h-5 w-5 text-red-600" />
+              <AlertCircle className="h-5 w-5 text-destructive" />
               <div>
-                <h3 className="font-medium text-red-800">Error memuat layanan</h3>
-                <p className="text-sm text-red-600">
+                <h3 className="font-medium text-destructive">Error memuat layanan</h3>
+                <p className="text-sm text-destructive/80">
                   Silakan coba refresh halaman atau hubungi dukungan jika masalah berlanjut.
                 </p>
               </div>
@@ -255,7 +255,7 @@ const ServiceManagement = () => {
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {services.map((service) => (
-          <Card key={service.id} className="hover:shadow-md transition-shadow">
+          <Card key={service.id} className="hover:shadow-medium transition-shadow">
             <CardHeader className="pb-3">
               <div className="flex items-center justify-between">
                 <CardTitle className="text-lg">{service.name}</CardTitle>
@@ -306,10 +306,10 @@ const ServiceManagement = () => {
                   Edit
                 </Button>
                 <Button
-                  variant="outline"
+                  variant="destructive"
                   size="sm"
                   onClick={() => handleDelete(service.id)}
-                  className="flex-1 text-red-600 hover:text-red-700"
+                  className="flex-1"
                 >
                   <Trash2 className="h-4 w-4 mr-1" />
                   Hapus

--- a/src/pages/WhatsAppBroadcastPage.tsx
+++ b/src/pages/WhatsAppBroadcastPage.tsx
@@ -244,7 +244,7 @@ export const WhatsAppBroadcastPage: React.FC = () => {
   if (!currentStore) {
     return (
       <div className="flex items-center justify-center h-64">
-        <p className="text-gray-500">Please select a store to send broadcast messages</p>
+        <p className="text-muted-foreground">Please select a store to send broadcast messages</p>
       </div>
     );
   }
@@ -267,21 +267,21 @@ export const WhatsAppBroadcastPage: React.FC = () => {
             <ArrowLeft className="h-4 w-4" />
           </Button>
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">WhatsApp Broadcast</h1>
-            <p className="text-gray-600">Send messages to multiple customers at once</p>
+            <h1 className="text-2xl font-bold text-foreground">WhatsApp Broadcast</h1>
+            <p className="text-muted-foreground">Send messages to multiple customers at once</p>
           </div>
         </div>
       </div>
 
       {/* WhatsApp Configuration Warning */}
       {!isConfigured && (
-        <Card className="border-yellow-500 bg-yellow-50">
+        <Card className="border-pos-warning/40 bg-pos-warning/10">
           <CardContent className="pt-6">
             <div className="flex items-start space-x-3">
-              <AlertCircle className="h-5 w-5 text-yellow-600 mt-0.5" />
+              <AlertCircle className="h-5 w-5 text-pos-warning mt-0.5" />
               <div>
-                <h3 className="font-medium text-yellow-900">WhatsApp Not Configured</h3>
-                <p className="text-sm text-yellow-800 mt-1">
+                <h3 className="font-medium text-pos-warning">WhatsApp Not Configured</h3>
+                <p className="text-sm text-pos-warning/80 mt-1">
                   WhatsApp service is not properly configured. Messages will not be sent.
                   Please check your environment variables.
                 </p>
@@ -315,7 +315,7 @@ export const WhatsAppBroadcastPage: React.FC = () => {
               {/* Search */}
               <div className="mb-4">
                 <div className="relative">
-                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
                   <Input
                     placeholder="Search customers by name, phone, or email..."
                     value={searchQuery}
@@ -334,9 +334,9 @@ export const WhatsAppBroadcastPage: React.FC = () => {
                 </div>
               ) : customers.length === 0 ? (
                 <div className="text-center py-8">
-                  <Users className="h-12 w-12 mx-auto text-gray-400 mb-4" />
-                  <h3 className="text-lg font-medium text-gray-900 mb-2">No customers found</h3>
-                  <p className="text-gray-600">
+                  <Users className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+                  <h3 className="text-lg font-medium text-foreground mb-2">No customers found</h3>
+                  <p className="text-muted-foreground">
                     {searchQuery ? 'Try adjusting your search terms' : 'No customers available in this store'}
                   </p>
                 </div>
@@ -350,7 +350,7 @@ export const WhatsAppBroadcastPage: React.FC = () => {
                             checked={allSelected}
                             onCheckedChange={handleSelectAll}
                             aria-label="Select all customers"
-                            className={someSelected ? "data-[state=checked]:bg-gray-500" : ""}
+                            className={someSelected ? "data-[state=checked]:bg-muted-foreground" : ""}
                           />
                         </TableHead>
                         <TableHead>Name</TableHead>
@@ -372,7 +372,7 @@ export const WhatsAppBroadcastPage: React.FC = () => {
                           </TableCell>
                           <TableCell className="font-medium">{customer.name}</TableCell>
                           <TableCell>{customer.phone}</TableCell>
-                          <TableCell className="text-gray-500">{customer.email || '-'}</TableCell>
+                          <TableCell className="text-muted-foreground">{customer.email || '-'}</TableCell>
                         </TableRow>
                       ))}
                     </TableBody>
@@ -405,33 +405,33 @@ export const WhatsAppBroadcastPage: React.FC = () => {
                   className="resize-none"
                 />
                 <div className="flex items-center justify-between mt-2">
-                  <p className="text-xs text-gray-500">
+                  <p className="text-xs text-muted-foreground">
                     {message.length} characters
                   </p>
                 </div>
-                <div className="mt-2 p-2 bg-gray-50 rounded border border-gray-200">
-                  <p className="text-xs font-medium text-gray-700 mb-1">Available variables:</p>
+                <div className="mt-2 p-2 bg-muted rounded border border-border">
+                  <p className="text-xs font-medium text-muted-foreground mb-1">Available variables:</p>
                   <div className="flex flex-wrap gap-2">
-                    <code className="text-xs bg-white px-2 py-1 rounded border border-gray-300">{'{{userName}}'}</code>
-                    <code className="text-xs bg-white px-2 py-1 rounded border border-gray-300">{'{{phone}}'}</code>
-                    <code className="text-xs bg-white px-2 py-1 rounded border border-gray-300">{'{{email}}'}</code>
+                    <code className="text-xs bg-background px-2 py-1 rounded border border-border">{'{{userName}}'}</code>
+                    <code className="text-xs bg-background px-2 py-1 rounded border border-border">{'{{phone}}'}</code>
+                    <code className="text-xs bg-background px-2 py-1 rounded border border-border">{'{{email}}'}</code>
                   </div>
                 </div>
               </div>
 
               {selectedCustomerIds.size > 0 && (
-                <div className="p-3 bg-blue-50 rounded-lg">
-                  <p className="text-sm font-medium text-blue-900 mb-2">
+                <div className="p-3 bg-pos-highlight/20 rounded-lg">
+                  <p className="text-sm font-medium text-primary mb-2">
                     Selected Recipients ({selectedCustomerIds.size})
                   </p>
                   <div className="space-y-1 max-h-32 overflow-y-auto">
                     {selectedCustomers.slice(0, MAX_RECIPIENTS_PREVIEW).map((customer) => (
-                      <p key={customer.id} className="text-xs text-blue-700">
+                      <p key={customer.id} className="text-xs text-primary/80">
                         • {customer.name}
                       </p>
                     ))}
                     {selectedCustomers.length > MAX_RECIPIENTS_PREVIEW && (
-                      <p className="text-xs text-blue-600">
+                      <p className="text-xs text-primary/70">
                         + {selectedCustomers.length - MAX_RECIPIENTS_PREVIEW} more
                       </p>
                     )}
@@ -487,7 +487,7 @@ export const WhatsAppBroadcastPage: React.FC = () => {
                     <TableCell>{result.phone}</TableCell>
                     <TableCell>
                       {result.success ? (
-                        <Badge variant="default" className="bg-green-600">
+                        <Badge variant="default" className="bg-pos-success">
                           <CheckCircle2 className="h-3 w-3 mr-1" />
                           Sent
                         </Badge>
@@ -498,7 +498,7 @@ export const WhatsAppBroadcastPage: React.FC = () => {
                         </Badge>
                       )}
                     </TableCell>
-                    <TableCell className="text-sm text-gray-500">
+                    <TableCell className="text-sm text-muted-foreground">
                       {result.error || 'Message delivered successfully'}
                     </TableCell>
                   </TableRow>

--- a/src/pages/WhatsAppBroadcastPage.tsx
+++ b/src/pages/WhatsAppBroadcastPage.tsx
@@ -347,10 +347,10 @@ export const WhatsAppBroadcastPage: React.FC = () => {
                       <TableRow>
                         <TableHead className="w-12">
                           <Checkbox
-                            checked={allSelected}
+                            checked={someSelected ? 'indeterminate' : allSelected}
                             onCheckedChange={handleSelectAll}
                             aria-label="Select all customers"
-                            className={someSelected ? "data-[state=checked]:bg-muted-foreground" : ""}
+                            className={someSelected ? "data-[state=indeterminate]:bg-muted-foreground" : ""}
                           />
                         </TableHead>
                         <TableHead>Name</TableHead>


### PR DESCRIPTION
## Summary

Four-phase pass preparing this app to ship as a native Android app via the Capacitor setup already in this repo (appId `com.smartlaundry.pos`, webDir `dist`).

**1. Printer: replace Web Bluetooth with native BLE**
`navigator.bluetooth` doesn't exist in Android's WebView, so thermal printing would silently break in the shipped app. Swapped in `@capacitor-community/bluetooth-le` (native BLE on Android/iOS, falls back to Web Bluetooth on web - same code path everywhere). Connection setup now discovers a device's real services/characteristics instead of guessing hardcoded UUIDs.

**2. Navigation: shared bottom tab bar**
The only mobile nav outside the Home page was the sidebar drawer behind a hamburger trigger - fine for the long tail, but native apps expect top destinations in a persistent bottom bar. Lifted the bottom-nav bar Home already had into `AppLayout` so every screen gets it, with a shared hook computing real per-route active state. The sidebar drawer stays for the rest (Pelanggan, Layanan, Broadcast, settings, sign out, etc).

**3. Native-shell affordances**
- Hardware Back button: closes open dialogs/sheets first (replays Escape, which Radix already handles), then goes back in-app, then exits on the root screen.
- Safe-area insets extended to `AppLayout`'s sticky header and the shared `Sheet` primitive (sidebar drawer), so content can't sit under the status bar or gesture nav bar.
- Status bar now overlays the WebView with dark icons for this app's light theme; native splash screen stays up until the app explicitly hides it post-render.
- The PWA "Install Aplikasi" UI (sidebar link + `usePWAInstall`'s `beforeinstallprompt` flow) is gated behind `Capacitor.isNativePlatform()` - it doesn't make sense once the app is already installed as a real APK.

**4. Restyle remaining screens to the design-token system**
Order History, Customers, Service Management, Login, and WhatsApp Broadcast still used one-off raw Tailwind colors left over from before Home/Store Management adopted the `pos-success`/`pos-warning`/`pos-highlight`/`destructive`/`muted` tokens. Mapped by real state semantics (completed→success, pending→warning, informational counts→highlight, errors/delete→destructive). The actual rendered order-list card lives in `VirtualizedOrderList.tsx` (a shared component) - restyled that directly since `OrderHistoryOptimized.tsx`'s own copy of the status-color functions turned out to be dead code.

Left alone, matching this repo's own established precedent: per-category service badges (9-way real differentiation) and payment-method brand colors (cash/QRIS - real payment-rail identity, not decoration).

## Test plan
- [x] `npx tsc -p tsconfig.app.json --noEmit` after every phase - only 2 pre-existing unrelated errors remain, none new
- [x] `npx eslint` on every touched file after every phase - zero new issues vs baseline (confirmed via before/after comparison), only pre-existing `@typescript-eslint/no-explicit-any`/`react-hooks/exhaustive-deps` remain
- [x] `npm run build` after every phase - succeeds
- [x] Dev server smoke test - `/home`, `/order-history`, `/customers`, `/services`, `/login`, `/whatsapp-broadcast` all serve 200 with no console/transform errors
- [ ] Manual on-device test: pair and print a real receipt to a Bluetooth thermal printer, exercise the bottom nav / back button / status bar on a real Android build, visual check of the restyled screens (no headless browser or Android emulator available in this sandbox)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native Bluetooth printing support, including improved printer discovery, connection handling, and reliable print delivery.
  - Added mobile bottom navigation with role-based destinations.
  - Added Android back-button behavior for dialogs, navigation, and app exit.
  - Improved native app launch experience with splash-screen, status-bar, and safe-area support.
  - Added automated Android build artifact generation.

- **Style**
  - Updated order, customer, login, history, service, and broadcast screens with consistent POS theme colors.
  - Improved mobile layout spacing and navigation visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->