### PR TITLE
feat(pos): inline quantity controls on service item cards

### DIFF
--- a/src/components/pos/EnhancedLaundryPOS.tsx
+++ b/src/components/pos/EnhancedLaundryPOS.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Search, Plus, Clock, CreditCard, User, ShoppingCart, CheckCircle, X, CheckCircle2, ArrowRight } from 'lucide-react';
+import { Search, Plus, Clock, CreditCard, User, ShoppingCart, CheckCircle, X, CheckCircle2, ArrowDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -99,6 +99,18 @@ export const EnhancedLaundryPOS = () => {
       });
     }
   };
+
+  // Live lookup of "what's already in the cart" for the service cards' steppers,
+  // keyed the same way as the card's own quantity request.
+  const quantities = React.useMemo(() => {
+    const map: Record<string, number> = {};
+    currentOrder.forEach(item => {
+      if (item.serviceType === 'unit' || item.serviceType === 'kilo') {
+        map[`${item.service.id}-${item.serviceType}`] = item.quantity;
+      }
+    });
+    return map;
+  }, [currentOrder]);
 
   // Get total price including both regular and dynamic items
   const getTotalPrice = () => {
@@ -211,10 +223,16 @@ export const EnhancedLaundryPOS = () => {
     });
   };
 
-  // Add a service straight to the real cart - one click adds at quantity 1
-  // (or 1kg for kilo), further adjustment happens in FloatingOrderSummary's
-  // cart list. No staging cart in between.
-  const addServiceToOrder = (rawService: CatalogService, type: 'unit' | 'kilo') => {
+  // Set a service line to an absolute quantity, straight on the real cart -
+  // the service card's stepper already computed the target value, including
+  // add (0 -> positive) and remove (-> 0). No staging cart in between, and no
+  // toast here: the live number on the card is its own feedback.
+  const setServiceQuantity = (rawService: CatalogService, type: 'unit' | 'kilo', quantity: number) => {
+    if (quantity <= 0) {
+      removeServiceFromOrder(rawService.id, type);
+      return;
+    }
+
     const price = type === 'unit' ? rawService.price : (rawService.kiloPrice || 0);
     const service = {
       id: rawService.id,
@@ -239,23 +257,22 @@ export const EnhancedLaundryPOS = () => {
           item.service.id === service.id && item.serviceType === type
             ? {
                 ...item,
-                quantity: item.quantity + 1,
-                totalPrice: (item.quantity + 1) * service.price,
-                weight: type === 'kilo' ? item.quantity + 1 : item.weight
+                quantity,
+                totalPrice: quantity * service.price,
+                weight: type === 'kilo' ? quantity : item.weight
               }
             : item
         );
       } else {
         return [...prev, {
           service,
-          quantity: 1,
+          quantity,
           serviceType: type,
-          weight: type === 'kilo' ? 1 : undefined,
-          totalPrice: service.price
+          weight: type === 'kilo' ? quantity : undefined,
+          totalPrice: quantity * service.price
         }];
       }
     });
-    notifyItemAdded(service.name);
   };
 
   // Add a composed custom item straight to the real cart
@@ -714,7 +731,7 @@ export const EnhancedLaundryPOS = () => {
                 className="gap-1.5"
               >
                 Pilih Layanan
-                <ArrowRight className="h-3.5 w-3.5" />
+                <ArrowDown className="h-3.5 w-3.5" />
               </Button>
             </div>
           )}
@@ -725,7 +742,8 @@ export const EnhancedLaundryPOS = () => {
       <Card ref={serviceSectionRef} className="shadow-medium animate-scale-in">
         <CardContent className="p-3 pt-4 sm:p-6 sm:pt-6">
           <InlineServiceSelector
-            onAddService={addServiceToOrder}
+            quantities={quantities}
+            onQuantityChange={setServiceQuantity}
             onAddCustomItem={addCustomItemToOrder}
             disabled={!customerName || !customerPhone}
             dropOffDate={dropOffDate}

--- a/src/components/pos/FloatingOrderSummary.tsx
+++ b/src/components/pos/FloatingOrderSummary.tsx
@@ -192,21 +192,21 @@ export const FloatingOrderSummary: React.FC<FloatingOrderSummaryProps> = ({
     return (
       <div className="fixed bottom-1 sm:bottom-4 left-1 sm:left-4 right-1 sm:right-4 z-50 max-w-lg mx-auto">
         <div className="relative">
-          <div className="absolute -top-2 left-1/2 h-1.5 w-10 -translate-x-1/2 rounded-full bg-primary/30" />
+          <div className="absolute -top-2 left-1/2 h-1.5 w-10 -translate-x-1/2 rounded-full bg-primary/60" />
           <button
             type="button"
             onClick={() => setIsExpanded(true)}
-            className={`flex w-full items-center justify-between gap-2 rounded-t-2xl rounded-b-xl border-2 border-t-2 border-dashed bg-card px-3 py-2.5 shadow-2xl transition-colors animate-slide-up sm:px-4 sm:py-3 ${
-              justAdded ? 'animate-button-success border-pos-success/50 bg-pos-success/10' : 'border-primary/25'
+            className={`flex w-full items-center justify-between gap-3 rounded-t-2xl rounded-b-xl bg-primary px-4 py-3.5 text-primary-foreground shadow-2xl transition-colors animate-slide-up sm:px-5 sm:py-4 ${
+              justAdded ? 'animate-button-success brightness-110' : ''
             }`}
           >
-            <div className="flex min-w-0 items-center gap-2">
-              <ShoppingCart className={`h-5 w-5 flex-shrink-0 ${justAdded ? 'text-pos-success' : 'text-primary'}`} />
-              <span className="truncate text-sm font-semibold text-foreground sm:text-base">
-                {itemCount} item · <span className="text-primary">Rp{formatCurrency(totalAmount)}</span>
+            <div className="flex min-w-0 items-center gap-2.5">
+              <ShoppingCart className="h-6 w-6 flex-shrink-0 text-primary-foreground sm:h-7 sm:w-7" />
+              <span className="truncate text-base font-semibold text-primary-foreground sm:text-lg">
+                {itemCount} item · <span className="font-bold text-primary-foreground">Rp{formatCurrency(totalAmount)}</span>
               </span>
             </div>
-            <ChevronUp className="h-5 w-5 flex-shrink-0 text-primary" />
+            <ChevronUp className="h-6 w-6 flex-shrink-0 text-primary-foreground sm:h-7 sm:w-7" />
           </button>
         </div>
       </div>

--- a/src/components/pos/InlineServiceSelector.tsx
+++ b/src/components/pos/InlineServiceSelector.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useServices } from '@/hooks/useServices';
+import { QuantityStepper, AddToCartButton } from './QuantityStepper';
 
 // Service interface for compatibility with existing Enhanced POS
 export interface Service {
@@ -35,14 +36,16 @@ export interface DynamicItem {
 }
 
 interface InlineServiceSelectorProps {
-  onAddService: (service: Service, type: 'unit' | 'kilo') => void;
+  quantities: Record<string, number>;
+  onQuantityChange: (service: Service, type: 'unit' | 'kilo', quantity: number) => void;
   onAddCustomItem: (item: DynamicItem) => void;
   disabled?: boolean;
   dropOffDate?: Date;
 }
 
 export const InlineServiceSelector: React.FC<InlineServiceSelectorProps> = ({
-  onAddService,
+  quantities,
+  onQuantityChange,
   onAddCustomItem,
   disabled = false,
   dropOffDate = new Date(),
@@ -50,7 +53,6 @@ export const InlineServiceSelector: React.FC<InlineServiceSelectorProps> = ({
   // Draft custom items being composed - cleared per-item once added to the order,
   // never a staging area for the real cart (services add straight to the order).
   const [dynamicItems, setDynamicItems] = useState<DynamicItem[]>([]);
-  const [animatingButton, setAnimatingButton] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const { data: servicesData = [], isLoading } = useServices();
 
@@ -164,14 +166,8 @@ export const InlineServiceSelector: React.FC<InlineServiceSelectorProps> = ({
     }
   };
 
-  const addService = (service: Service, type: 'unit' | 'kilo') => {
-    // Trigger animation
-    const buttonKey = `${service.id}-${type}`;
-    setAnimatingButton(buttonKey);
-    setTimeout(() => setAnimatingButton(null), 300);
-
-    onAddService(service, type);
-  };
+  const getQuantity = (serviceId: string, type: 'unit' | 'kilo') =>
+    quantities[`${serviceId}-${type}`] ?? 0;
 
   const addDynamicItem = () => {
     const newItem: DynamicItem = {
@@ -296,30 +292,44 @@ export const InlineServiceSelector: React.FC<InlineServiceSelectorProps> = ({
                             </p>
                           )}
 
-                          <div className="mt-2 flex gap-1.5 sm:mt-3 sm:gap-2">
+                          <div className="mt-2 flex flex-col gap-1.5 sm:mt-3">
                             {service.supportsUnit && service.price && (
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => addService(service, 'unit')}
-                                disabled={disabled}
-                                className={`h-8 flex-1 text-xs transition-all sm:h-9 sm:text-sm ${animatingButton === `${service.id}-unit` ? 'animate-button-success bg-pos-success/10 border-pos-success/40' : ''}`}
-                              >
-                                <Plus className="h-3 w-3 mr-1" />
-                                Tambah Satuan
-                              </Button>
+                              <div className="flex items-center justify-between gap-1.5 rounded-md border p-1.5">
+                                <span className="text-[11px] text-muted-foreground sm:text-xs">Satuan</span>
+                                <div className="flex items-center gap-1.5">
+                                  <QuantityStepper
+                                    value={getQuantity(service.id, 'unit')}
+                                    unitType="unit"
+                                    disabled={disabled}
+                                    onChange={(qty) => onQuantityChange(service, 'unit', qty)}
+                                  />
+                                  <AddToCartButton
+                                    value={getQuantity(service.id, 'unit')}
+                                    unitType="unit"
+                                    disabled={disabled}
+                                    onChange={(qty) => onQuantityChange(service, 'unit', qty)}
+                                  />
+                                </div>
+                              </div>
                             )}
                             {service.supportsKilo && service.kiloPrice && (
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => addService(service, 'kilo')}
-                                disabled={disabled}
-                                className={`h-8 flex-1 text-xs transition-all sm:h-9 sm:text-sm ${animatingButton === `${service.id}-kilo` ? 'animate-button-success bg-pos-success/10 border-pos-success/40' : ''}`}
-                              >
-                                <Plus className="h-3 w-3 mr-1" />
-                                Tambah Kilo
-                              </Button>
+                              <div className="flex items-center justify-between gap-1.5 rounded-md border p-1.5">
+                                <span className="text-[11px] text-muted-foreground sm:text-xs">Kilo</span>
+                                <div className="flex items-center gap-1.5">
+                                  <QuantityStepper
+                                    value={getQuantity(service.id, 'kilo')}
+                                    unitType="kilo"
+                                    disabled={disabled}
+                                    onChange={(qty) => onQuantityChange(service, 'kilo', qty)}
+                                  />
+                                  <AddToCartButton
+                                    value={getQuantity(service.id, 'kilo')}
+                                    unitType="kilo"
+                                    disabled={disabled}
+                                    onChange={(qty) => onQuantityChange(service, 'kilo', qty)}
+                                  />
+                                </div>
+                              </div>
                             )}
                           </div>
                         </Card>
@@ -356,18 +366,25 @@ export const InlineServiceSelector: React.FC<InlineServiceSelectorProps> = ({
                             </div>
                           </div>
 
-                          <div className="mt-2 flex gap-1.5 sm:mt-3 sm:gap-2">
+                          <div className="mt-2 sm:mt-3">
                             {product.supportsUnit && product.price && (
-                              <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={() => addService(product, 'unit')}
-                                disabled={disabled}
-                                className={`h-8 flex-1 text-xs transition-all border-cyan-300 hover:bg-cyan-100 sm:h-9 sm:text-sm ${animatingButton === `${product.id}-unit` ? 'animate-button-success bg-pos-success/10 border-pos-success/40' : ''}`}
-                              >
-                                <Plus className="h-3 w-3 mr-1" />
-                                Tambah Produk
-                              </Button>
+                              <div className="flex items-center justify-between gap-1.5 rounded-md border border-cyan-300 bg-cyan-50/50 p-1.5">
+                                <span className="text-[11px] text-cyan-700 sm:text-xs">Jumlah</span>
+                                <div className="flex items-center gap-1.5">
+                                  <QuantityStepper
+                                    value={getQuantity(product.id, 'unit')}
+                                    unitType="unit"
+                                    disabled={disabled}
+                                    onChange={(qty) => onQuantityChange(product, 'unit', qty)}
+                                  />
+                                  <AddToCartButton
+                                    value={getQuantity(product.id, 'unit')}
+                                    unitType="unit"
+                                    disabled={disabled}
+                                    onChange={(qty) => onQuantityChange(product, 'unit', qty)}
+                                  />
+                                </div>
+                              </div>
                             )}
                           </div>
                         </Card>

--- a/src/components/pos/QuantityStepper.tsx
+++ b/src/components/pos/QuantityStepper.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Minus, Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+
+type UnitType = 'unit' | 'kilo';
+
+const STEP: Record<UnitType, number> = { unit: 1, kilo: 0.1 };
+const FIRST_STEP: Record<UnitType, number> = { unit: 1, kilo: 1 };
+
+const roundKilo = (value: number) => Math.round(value * 10) / 10;
+
+export const getIncrementedValue = (value: number, unitType: UnitType) => {
+  const next = value <= 0 ? FIRST_STEP[unitType] : value + STEP[unitType];
+  return unitType === 'kilo' ? roundKilo(next) : next;
+};
+
+const getDecrementedValue = (value: number, unitType: UnitType) => {
+  const next = Math.max(0, value - STEP[unitType]);
+  return unitType === 'kilo' ? roundKilo(next) : next;
+};
+
+interface QuantityStepperProps {
+  value: number;
+  unitType: UnitType;
+  disabled?: boolean;
+  onChange: (newValue: number) => void;
+  className?: string;
+}
+
+export const QuantityStepper: React.FC<QuantityStepperProps> = ({
+  value,
+  unitType,
+  disabled = false,
+  onChange,
+  className = '',
+}) => {
+  const handleTyped = (raw: string) => {
+    if (raw.trim() === '') {
+      onChange(0);
+      return;
+    }
+    const parsed = unitType === 'kilo' ? parseFloat(raw) : parseInt(raw, 10);
+    if (isNaN(parsed)) return;
+    const clamped = Math.max(0, parsed);
+    onChange(unitType === 'kilo' ? roundKilo(clamped) : clamped);
+  };
+
+  return (
+    <div className={`flex items-center gap-1 ${className}`}>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => onChange(getDecrementedValue(value, unitType))}
+        disabled={disabled || value <= 0}
+        className="h-8 w-8 flex-shrink-0 p-0 sm:h-9 sm:w-9"
+      >
+        <Minus className="h-3.5 w-3.5" />
+      </Button>
+      <Input
+        type="number"
+        inputMode={unitType === 'kilo' ? 'decimal' : 'numeric'}
+        step={unitType === 'kilo' ? '0.1' : '1'}
+        min="0"
+        placeholder="0"
+        value={value === 0 ? '' : value}
+        onChange={(e) => handleTyped(e.target.value)}
+        disabled={disabled}
+        className="h-8 w-12 flex-shrink-0 [appearance:textfield] text-center text-xs [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none sm:h-9 sm:w-14 sm:text-sm"
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => onChange(getIncrementedValue(value, unitType))}
+        disabled={disabled || value <= 0}
+        className="h-8 w-8 flex-shrink-0 p-0 sm:h-9 sm:w-9"
+      >
+        <Plus className="h-3.5 w-3.5" />
+      </Button>
+    </div>
+  );
+};
+
+interface AddToCartButtonProps {
+  value: number;
+  unitType: UnitType;
+  disabled?: boolean;
+  onChange: (newValue: number) => void;
+  className?: string;
+}
+
+export const AddToCartButton: React.FC<AddToCartButtonProps> = ({
+  value,
+  unitType,
+  disabled = false,
+  onChange,
+  className = '',
+}) => (
+  <Button
+    type="button"
+    variant="pos"
+    size="sm"
+    onClick={() => onChange(FIRST_STEP[unitType])}
+    disabled={disabled || value > 0}
+    className={`h-8 flex-shrink-0 gap-1 px-3 text-xs sm:h-9 sm:text-sm ${className}`}
+  >
+    <Plus className="h-3.5 w-3.5" />
+    Tambah
+  </Button>
+);


### PR DESCRIPTION
## Summary
- Service and product cards in the POS add-item flow now show a live +/- stepper with a typable number field, so staff can set quantity directly on the card instead of tapping repeatedly and adjusting afterward in the cart list.
- Added a dedicated "Tambah" button for the initial add-to-cart action; the stepper's own +/- only adjusts quantity for items already in the cart (roles are intentionally separate, not interchangeable).
- Card and cart stay in sync live (no separate staging/draft step) via a new `quantities` lookup passed down from `EnhancedLaundryPOS`.
- Floating collapsed cart bar is bigger and now uses a solid primary-blue background for visibility.
- Fixed the "Pilih Layanan" CTA using a right-pointing arrow that implied next-page navigation; it now scrolls down to the service section, so the icon is a down arrow.
- Fixed a leading-zero input artifact ("05") when typing a quantity from an empty/zero field.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run build` — clean
- [x] `npm run lint` — only pre-existing unrelated errors
- [ ] Manual click-through in browser (no browser automation tool available in this session — please verify add/remove/type flows on a device before merging)