### PR TITLE
feat(app): minimal app-shell welcome screen for native/PWA pre-login

### DIFF
--- a/src/hooks/usePWAInstall.ts
+++ b/src/hooks/usePWAInstall.ts
@@ -13,8 +13,15 @@ interface BeforeInstallPromptEvent extends Event {
 export const usePWAInstall = () => {
   const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
   const [isInstallable, setIsInstallable] = useState(false);
-  // Already installed by definition inside the native app shell.
-  const [isInstalled, setIsInstalled] = useState(() => Capacitor.isNativePlatform());
+  // Already installed by definition inside the native app shell or an installed
+  // (standalone-display-mode) PWA - computed synchronously so consumers that branch
+  // UI on this value (e.g. SmartHomePage picking a welcome screen) never flash the
+  // "not installed" state for a frame before this flips true.
+  const [isInstalled, setIsInstalled] = useState(() =>
+    Capacitor.isNativePlatform() ||
+    window.matchMedia('(display-mode: standalone)').matches ||
+    (window.navigator as any).standalone === true
+  );
 
   useEffect(() => {
     // Already installed by definition inside the native app shell - the browser-only
@@ -39,15 +46,9 @@ export const usePWAInstall = () => {
 
     // Listen for the beforeinstallprompt event
     window.addEventListener('beforeinstallprompt', handleBeforeInstallPrompt as EventListener);
-    
+
     // Listen for the appinstalled event
     window.addEventListener('appinstalled', handleAppInstalled);
-
-    // Check if app is already installed (standalone mode)
-    if (window.matchMedia('(display-mode: standalone)').matches || 
-        (window.navigator as any).standalone === true) {
-      setIsInstalled(true);
-    }
 
     // Check for iOS Safari "Add to Home Screen" prompt
     const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);

--- a/src/pages/AppWelcomeScreen.tsx
+++ b/src/pages/AppWelcomeScreen.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import './LandingPage.css';
+
+/**
+ * Pre-login screen shown inside the native app / installed PWA, in place of
+ * the full marketing LandingPage - an app-shell user already installed the
+ * app, they just want to log in or sign up. Reuses the LandingPage's
+ * ticket-stub design language (.tk-page) but intentionally skips its Google
+ * Fonts network fetch so the app's first screen has no network dependency;
+ * the --tk-font-* variables already fall back to system fonts.
+ */
+export const AppWelcomeScreen: React.FC = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div
+      className="tk-page min-h-screen flex flex-col items-center justify-center text-center"
+      style={{
+        paddingTop: 'max(1.5rem, env(safe-area-inset-top))',
+        paddingBottom: 'max(1.5rem, env(safe-area-inset-bottom))',
+        paddingLeft: 'max(1.5rem, env(safe-area-inset-left))',
+        paddingRight: 'max(1.5rem, env(safe-area-inset-right))',
+      }}
+    >
+      <div className="w-16 h-16 flex-shrink-0 border-2 border-[var(--tk-ink)] rounded-sm flex items-center justify-center tk-mono font-bold text-[var(--tk-ink)] text-xl">
+        SL
+      </div>
+      <div className="mt-4">
+        <span className="block text-2xl font-bold text-[var(--tk-graphite)]">
+          Smart Laundry POS
+        </span>
+        <p className="text-xs tk-mono tracking-wide text-[var(--tk-graphite-soft)] mt-1">
+          SISTEM KASIR LAUNDRY
+        </p>
+      </div>
+
+      <div className="tk-perforation w-full max-w-xs my-8" />
+
+      <p className="text-base text-[var(--tk-graphite-soft)] max-w-xs">
+        Kasir laundry yang jalan secepat antrian pagi.
+      </p>
+
+      <div className="w-full max-w-xs mt-10 flex flex-col gap-3">
+        <button
+          onClick={() => navigate('/login')}
+          className="w-full inline-flex items-center justify-center px-5 py-3 text-base font-semibold rounded-sm bg-[var(--tk-ink)] text-[var(--tk-paper)] hover:bg-[var(--tk-graphite)] transition-colors"
+        >
+          Masuk
+        </button>
+        <button
+          onClick={() => navigate('/login?tab=signup')}
+          className="w-full inline-flex items-center justify-center px-5 py-3 text-base font-medium rounded-sm border border-[var(--tk-line)] text-[var(--tk-ink-soft)] hover:bg-[var(--tk-paper-soft)] transition-colors"
+        >
+          Daftar akun baru
+        </button>
+      </div>
+    </div>
+  );
+};

--- a/src/pages/SmartHomePage.tsx
+++ b/src/pages/SmartHomePage.tsx
@@ -1,12 +1,17 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
+import { usePWAInstall } from '@/hooks/usePWAInstall';
 import { LandingPage } from './LandingPage';
+import { AppWelcomeScreen } from './AppWelcomeScreen';
 import { PageLoading } from '@/components/ui/loading-spinner';
 
 export const SmartHomePage = () => {
   const navigate = useNavigate();
   const { user, loading } = useAuth();
+  // True inside the native app shell or an installed (standalone) PWA - both
+  // get the minimal AppWelcomeScreen instead of the marketing LandingPage.
+  const { isInstalled: isAppShell } = usePWAInstall();
 
   useEffect(() => {
     // If user is authenticated and not loading, redirect to POS
@@ -25,6 +30,6 @@ export const SmartHomePage = () => {
     return <PageLoading text="Mengalihkan ke POS..." />;
   }
 
-  // If user is not authenticated, show landing page
-  return <LandingPage />;
+  // If user is not authenticated, show the appropriate landing experience
+  return isAppShell ? <AppWelcomeScreen /> : <LandingPage />;
 };


### PR DESCRIPTION
## Summary
- The native Android app and installed PWA currently open to the full desktop marketing `LandingPage` before login (hero, screenshots, competitor comparison table, footer, floating WhatsApp button) — fine for a web visitor, but an unusual first screen for someone who already installed the app.
- Adds a minimal `AppWelcomeScreen` (reuses the existing ticket-stub design language and the "SL" mark, no new assets/colors) with primary **Masuk** and secondary **Daftar akun baru** actions, shown instead of `LandingPage` when `Capacitor.isNativePlatform()` or the PWA is running in standalone display mode. The web marketing `LandingPage` is untouched for regular browser visitors.
- Also makes `usePWAInstall`'s `isInstalled` check standalone-mode synchronously (previously only detected in a post-mount `useEffect`) to avoid a one-frame flash between the two screens on cold PWA opens.

## Test plan
- [x] `npx tsc -p tsconfig.app.json --noEmit` — only the 2 pre-existing unrelated errors on `main`
- [x] `npx eslint` on all touched/new files — zero new issues vs. baseline
- [x] `npm run build` — succeeds
- [x] Playwright smoke test against `npm run dev`: confirmed regular web load still shows the marketing `LandingPage` with no console errors, and simulated standalone mode (`navigator.standalone = true`) shows `AppWelcomeScreen` with both buttons visible and none of the marketing-only content (e.g. competitor table) present, no console errors
- [ ] Real-device follow-up: install the PWA or build the APK via `build-android.yml` and confirm a cold app open shows the new welcome screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a branded welcome screen for unauthenticated users in installed app and native app environments.
  * Added clear navigation options to sign in or create an account.
  * Improved launch behavior by immediately detecting installed app mode.

* **Bug Fixes**
  * Preserved existing loading and authenticated-user redirect behavior across app environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->