### PR TITLE
feat(android): add signed release APK build with real versioning

### DIFF
--- a/.github/scripts/patch-android-release-gradle.cjs
+++ b/.github/scripts/patch-android-release-gradle.cjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+// Patches the Capacitor-generated android/app/build.gradle with a real version and a
+// release signingConfig. android/ isn't committed to this repo (see capacitor.config.ts
+// and .gitignore) - CI regenerates it fresh from Capacitor's template on every run, which
+// always hardcodes versionCode 1 / versionName "1.0" and has no release signing wired up.
+//
+// Expects RELEASE_VERSION_CODE and RELEASE_VERSION_NAME env vars. The signing config
+// references ANDROID_RELEASE_STORE_FILE/STORE_PASSWORD/KEY_ALIAS/KEY_PASSWORD via
+// System.getenv(...) directly in the generated Gradle file, so those secrets never need
+// to be written to disk as plaintext - they're read from the environment at build time.
+const fs = require('fs');
+const path = require('path');
+
+const gradlePath = path.join(__dirname, '..', '..', 'android', 'app', 'build.gradle');
+const versionCode = process.env.RELEASE_VERSION_CODE;
+const versionName = process.env.RELEASE_VERSION_NAME;
+
+if (!versionCode || !versionName) {
+  console.error('RELEASE_VERSION_CODE and RELEASE_VERSION_NAME must be set');
+  process.exit(1);
+}
+
+let content = fs.readFileSync(gradlePath, 'utf8');
+
+const replace = (from, to) => {
+  if (!content.includes(from)) {
+    console.error(`Expected to find in build.gradle, template may have changed:\n${from}`);
+    process.exit(1);
+  }
+  content = content.replace(from, to);
+};
+
+replace('versionCode 1', `versionCode ${versionCode}`);
+replace('versionName "1.0"', `versionName "${versionName}"`);
+
+replace(
+  'buildTypes {',
+  `signingConfigs {
+        release {
+            storeFile file(System.getenv("ANDROID_RELEASE_STORE_FILE"))
+            storePassword System.getenv("ANDROID_RELEASE_STORE_PASSWORD")
+            keyAlias System.getenv("ANDROID_RELEASE_KEY_ALIAS")
+            keyPassword System.getenv("ANDROID_RELEASE_KEY_PASSWORD")
+        }
+    }
+    buildTypes {`
+);
+
+replace(
+  'release {\n            minifyEnabled false',
+  'release {\n            signingConfig signingConfigs.release\n            minifyEnabled false'
+);
+
+fs.writeFileSync(gradlePath, content);
+console.log(`Patched android/app/build.gradle: versionCode=${versionCode} versionName=${versionName}`);

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -37,6 +37,15 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # Gradle evaluates the whole build.gradle - including the signingConfigs block added
+      # by the patch script - during project configuration regardless of which task runs,
+      # so these must be visible to every Gradle invocation in this job, not just the
+      # release one, or even `assembleDebug` fails resolving file(System.getenv(...)).
+      ANDROID_RELEASE_STORE_FILE: release.keystore
+      ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+      ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+      ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -54,11 +63,14 @@ jobs:
         # WhatsApp credentials stay server-side (Vercel serverless function) - these are
         # just feature flags plus the deployed site's absolute origin, since the packaged
         # app's WebView has no backend of its own at its local origin to resolve a
-        # relative API path against. None of these values are sensitive.
+        # relative API path against. VITE_GOOGLE_CLIENT_ID is a public OAuth client ID
+        # (meant to appear in frontend requests), not a secret. None of these values need
+        # to be kept out of the workflow file.
         env:
           VITE_WHATSAPP_ENABLED: 'true'
           VITE_WHATSAPP_NOTIFY_ORDER_CREATED: 'true'
           VITE_APP_ORIGIN: 'https://pos.fahrudina.my.id'
+          VITE_GOOGLE_CLIENT_ID: '215218745424-fdgt918nk9alov6vacn4n41670k2u2hq.apps.googleusercontent.com'
         run: npm run build
 
       - name: Set up JDK
@@ -97,11 +109,6 @@ jobs:
 
       - name: Build release APK
         working-directory: android
-        env:
-          ANDROID_RELEASE_STORE_FILE: release.keystore
-          ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
-          ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
-          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
         run: ./gradlew assembleRelease --no-daemon
 
       - name: Upload debug APK

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -2,10 +2,15 @@ name: Build Android
 
 # This repo doesn't check the generated android/ native project into git (see
 # capacitor.config.ts) - this workflow regenerates it fresh from the web build
-# every run via `cap add`/`cap sync`, then builds a debug APK with Gradle.
-# There's no release signing set up yet, so this produces a debug build only,
-# good for verifying the Capacitor+Gradle pipeline still builds and for
-# sideloading onto a test device - not for a Play Store release.
+# every run via `cap add`/`cap sync`, then builds both a debug APK and a signed
+# release APK with Gradle. Both are for direct sideload distribution (install
+# the APK directly on a device) - there's no Play Store submission set up,
+# that would need an .aab bundle and a Play Console listing instead.
+#
+# The release APK is signed with a permanent key stored as GitHub secrets
+# (ANDROID_RELEASE_KEYSTORE_BASE64/STORE_PASSWORD/KEY_ALIAS/KEY_PASSWORD) -
+# every future release must keep using this same key, or devices with an
+# earlier release installed won't be able to update in place.
 
 on:
   push:
@@ -74,14 +79,43 @@ jobs:
       - name: Sync web build into native project
         run: npx cap sync android
 
+      - name: Compute release version
+        run: |
+          echo "RELEASE_VERSION_CODE=${{ github.run_number }}" >> "$GITHUB_ENV"
+          echo "RELEASE_VERSION_NAME=$(date -u +%Y.%m.%d)-${{ github.run_number }}" >> "$GITHUB_ENV"
+
+      - name: Patch Android version and release signing config
+        run: node .github/scripts/patch-android-release-gradle.cjs
+
+      - name: Decode release keystore
+        working-directory: android/app
+        run: echo "${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}" | base64 --decode > release.keystore
+
       - name: Build debug APK
         working-directory: android
         run: ./gradlew assembleDebug --no-daemon
+
+      - name: Build release APK
+        working-directory: android
+        env:
+          ANDROID_RELEASE_STORE_FILE: release.keystore
+          ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+          ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+          ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+        run: ./gradlew assembleRelease --no-daemon
 
       - name: Upload debug APK
         uses: actions/upload-artifact@v4
         with:
           name: smart-laundry-pos-debug-apk
           path: android/app/build/outputs/apk/debug/app-debug.apk
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Upload release APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: smart-laundry-pos-release-apk
+          path: android/app/build/outputs/apk/release/app-release.apk
           retention-days: 14
           if-no-files-found: error

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -111,6 +111,31 @@ jobs:
         working-directory: android
         run: ./gradlew assembleRelease --no-daemon
 
+      - name: Verify release APK signer
+        # Confirms the built APK is actually signed with the expected permanent key,
+        # not a different/wrong keystore - a mismatch here would silently break
+        # in-place updates for anyone who already installed a build signed with the
+        # real key, so this fails the workflow before either APK gets uploaded.
+        working-directory: android
+        env:
+          EXPECTED_SIGNER_SHA256: ${{ secrets.ANDROID_RELEASE_EXPECTED_SIGNER_SHA256 }}
+        run: |
+          set -euo pipefail
+          if [ -z "${EXPECTED_SIGNER_SHA256:-}" ]; then
+            echo "::error::ANDROID_RELEASE_EXPECTED_SIGNER_SHA256 secret is not set - refusing to publish an unverified release APK"
+            exit 1
+          fi
+          APKSIGNER=$(find "$ANDROID_HOME/build-tools" -name apksigner | sort -V | tail -1)
+          ACTUAL_SHA256=$("$APKSIGNER" verify --verbose --print-certs app/build/outputs/apk/release/app-release.apk \
+            | grep "Signer #1 certificate SHA-256 digest" | awk -F': ' '{print $2}' | tr 'A-Z' 'a-z')
+          EXPECTED_SHA256=$(echo "$EXPECTED_SIGNER_SHA256" | tr -d ':' | tr 'A-Z' 'a-z')
+          echo "Release APK signer SHA-256: $ACTUAL_SHA256"
+          if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+            echo "::error::Release APK signer SHA-256 ($ACTUAL_SHA256) does not match the expected signing key ($EXPECTED_SHA256)"
+            exit 1
+          fi
+          echo "Release APK signer verified OK"
+
       - name: Upload debug APK
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- The Capacitor-generated `android/app/build.gradle` (regenerated fresh by CI every run, not committed to this repo) hardcodes `versionCode 1` / `versionName "1.0"` and has no release signing - every build was version-identical and there was no signed APK suitable for distributing to store owners/staff, only manual debug sideloads.
- Adds `.github/scripts/patch-android-release-gradle.cjs`, run after `cap add android`, which sets `versionCode` from the CI run number and `versionName` from build date + run number, and wires a release `signingConfig` that reads the keystore/passwords from environment variables at build time (no key material committed).
- New GitHub Actions secrets: `ANDROID_RELEASE_KEYSTORE_BASE64`, `ANDROID_RELEASE_STORE_PASSWORD`, `ANDROID_RELEASE_KEY_ALIAS`, `ANDROID_RELEASE_KEY_PASSWORD` (already added to the repo).
- Produces a new `smart-laundry-pos-release-apk` artifact alongside the existing debug build. Still sideload-only (no Play Store `.aab`/listing set up).

**Important**: the release keystore is a brand-new, permanent signing identity - I generated it and handed a local backup copy + password to the repo owner directly (not committed anywhere). Every future release build must keep using this same key or devices with an earlier release installed won't be able to update in place.

## Test plan
- [x] Verified the patch script locally against a real `npx cap add android` output - versionCode/versionName/signingConfig land in `build.gradle` exactly as expected
- [x] Built a signed release APK locally end-to-end with the generated keystore - `BUILD SUCCESSFUL`, `jarsigner -verify` confirms valid signature, `aapt dump badging` confirms correct `versionCode`/`versionName`/`applicationId`
- [ ] Trigger this workflow in CI (`workflow_dispatch`) and confirm the release APK artifact builds and installs on a real device

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Release**
  * Android builds now generate signed release APKs with release version metadata.
  * Release APKs are uploaded alongside debug APK artifacts for easier distribution.
  * Added validation for required release settings and signing configuration during builds.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->