### PR TITLE
fix(android): fix signer verification, add tag-triggered release workflow

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -120,14 +120,40 @@ jobs:
         env:
           EXPECTED_SIGNER_SHA256: ${{ secrets.ANDROID_RELEASE_EXPECTED_SIGNER_SHA256 }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           if [ -z "${EXPECTED_SIGNER_SHA256:-}" ]; then
             echo "::error::ANDROID_RELEASE_EXPECTED_SIGNER_SHA256 secret is not set - refusing to publish an unverified release APK"
             exit 1
           fi
-          APKSIGNER=$(find "$ANDROID_HOME/build-tools" -name apksigner | sort -V | tail -1)
-          ACTUAL_SHA256=$("$APKSIGNER" verify --verbose --print-certs app/build/outputs/apk/release/app-release.apk \
-            | grep "Signer #1 certificate SHA-256 digest" | awk -F': ' '{print $2}' | tr 'A-Z' 'a-z')
+
+          # Gradle signs via its own bundled apksig library, not necessarily the SDK's
+          # standalone build-tools CLI - don't assume that directory is populated.
+          APKSIGNER=$(find "$ANDROID_HOME" -type f -name apksigner 2>/dev/null | sort -V | tail -1)
+          if [ -z "$APKSIGNER" ]; then
+            echo "apksigner not found under \$ANDROID_HOME ($ANDROID_HOME) - installing build-tools"
+            yes | sdkmanager --install "build-tools;35.0.0" > /dev/null
+            APKSIGNER=$(find "$ANDROID_HOME" -type f -name apksigner 2>/dev/null | sort -V | tail -1)
+          fi
+          if [ -z "$APKSIGNER" ]; then
+            echo "::error::Could not locate apksigner even after installing build-tools;35.0.0"
+            exit 1
+          fi
+          echo "Using apksigner: $APKSIGNER"
+
+          VERIFY_OUTPUT=$("$APKSIGNER" verify --verbose --print-certs app/build/outputs/apk/release/app-release.apk)
+          verify_exit=$?
+          echo "$VERIFY_OUTPUT"
+          if [ "$verify_exit" -ne 0 ]; then
+            echo "::error::apksigner verify failed (exit $verify_exit)"
+            exit 1
+          fi
+
+          ACTUAL_SHA256=$(echo "$VERIFY_OUTPUT" | grep "Signer #1 certificate SHA-256 digest" | awk -F': ' '{print $2}' | tr 'A-Z' 'a-z')
+          if [ -z "$ACTUAL_SHA256" ]; then
+            echo "::error::Could not extract signer SHA-256 digest from apksigner output"
+            exit 1
+          fi
+
           EXPECTED_SHA256=$(echo "$EXPECTED_SIGNER_SHA256" | tr -d ':' | tr 'A-Z' 'a-z')
           echo "Release APK signer SHA-256: $ACTUAL_SHA256"
           if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -148,7 +148,12 @@ jobs:
             exit 1
           fi
 
-          ACTUAL_SHA256=$(echo "$VERIFY_OUTPUT" | grep "Signer #1 certificate SHA-256 digest" | awk -F': ' '{print $2}' | tr 'A-Z' 'a-z')
+          # apksigner's output format varies by build-tools version - older versions print
+          # "Signer #1 certificate SHA-256 digest: ...", newer ones print "V2 Signer:
+          # certificate SHA-256 digest: ..." - match on the common "certificate SHA-256
+          # digest" substring and split on "digest: " rather than the first colon, since
+          # newer output has an earlier colon in the "V2 Signer:" prefix.
+          ACTUAL_SHA256=$(echo "$VERIFY_OUTPUT" | grep -m1 "certificate SHA-256 digest" | awk -F'digest: ' '{print $2}' | tr 'A-Z' 'a-z')
           if [ -z "$ACTUAL_SHA256" ]; then
             echo "::error::Could not extract signer SHA-256 digest from apksigner output"
             exit 1

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,0 +1,152 @@
+name: Release Android
+
+# Triggered by pushing a version tag (v1.2.3) - builds a signed release APK using the
+# same permanent signing key as build-android.yml's workflow_dispatch/main-push release
+# build, then publishes it as a GitHub Release asset for that tag. Kept as a separate
+# workflow from build-android.yml (which builds on every main push, for CI smoke-testing
+# and ad-hoc sideloads) since a pushed tag is an intentional "this is a real release"
+# event with its own version scheme: versionName comes from the tag itself (v1.2.3 ->
+# 1.2.3) rather than the date+run-number scheme used for untagged builds.
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-android-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      # Gradle evaluates the whole build.gradle - including the signingConfigs block added
+      # by the patch script - during project configuration regardless of which task runs,
+      # so these must be visible to the Gradle invocation below.
+      ANDROID_RELEASE_STORE_FILE: release.keystore
+      ANDROID_RELEASE_STORE_PASSWORD: ${{ secrets.ANDROID_RELEASE_STORE_PASSWORD }}
+      ANDROID_RELEASE_KEY_ALIAS: ${{ secrets.ANDROID_RELEASE_KEY_ALIAS }}
+      ANDROID_RELEASE_KEY_PASSWORD: ${{ secrets.ANDROID_RELEASE_KEY_PASSWORD }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build web app
+        # See build-android.yml for why these are set here and why none need to be secret.
+        env:
+          VITE_WHATSAPP_ENABLED: 'true'
+          VITE_WHATSAPP_NOTIFY_ORDER_CREATED: 'true'
+          VITE_APP_ORIGIN: 'https://pos.fahrudina.my.id'
+          VITE_GOOGLE_CLIENT_ID: '215218745424-fdgt918nk9alov6vacn4n41670k2u2hq.apps.googleusercontent.com'
+        run: npm run build
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Add Android platform
+        run: npx cap add android
+
+      - name: Sync web build into native project
+        run: npx cap sync android
+
+      - name: Compute release version from tag
+        run: |
+          TAG_NAME="${{ github.ref_name }}"
+          echo "RELEASE_VERSION_CODE=${{ github.run_number }}" >> "$GITHUB_ENV"
+          echo "RELEASE_VERSION_NAME=${TAG_NAME#v}" >> "$GITHUB_ENV"
+
+      - name: Patch Android version and release signing config
+        run: node .github/scripts/patch-android-release-gradle.cjs
+
+      - name: Decode release keystore
+        working-directory: android/app
+        run: echo "${{ secrets.ANDROID_RELEASE_KEYSTORE_BASE64 }}" | base64 --decode > release.keystore
+
+      - name: Build release APK
+        working-directory: android
+        run: ./gradlew assembleRelease --no-daemon
+
+      - name: Verify release APK signer
+        # Confirms the built APK is actually signed with the expected permanent key,
+        # not a different/wrong keystore - a mismatch here would silently break
+        # in-place updates for anyone who already installed a build signed with the
+        # real key, so this fails the workflow before the GitHub Release gets created.
+        working-directory: android
+        env:
+          EXPECTED_SIGNER_SHA256: ${{ secrets.ANDROID_RELEASE_EXPECTED_SIGNER_SHA256 }}
+        run: |
+          set -uo pipefail
+          if [ -z "${EXPECTED_SIGNER_SHA256:-}" ]; then
+            echo "::error::ANDROID_RELEASE_EXPECTED_SIGNER_SHA256 secret is not set - refusing to publish an unverified release APK"
+            exit 1
+          fi
+
+          # Gradle signs via its own bundled apksig library, not necessarily the SDK's
+          # standalone build-tools CLI - don't assume that directory is populated.
+          APKSIGNER=$(find "$ANDROID_HOME" -type f -name apksigner 2>/dev/null | sort -V | tail -1)
+          if [ -z "$APKSIGNER" ]; then
+            echo "apksigner not found under \$ANDROID_HOME ($ANDROID_HOME) - installing build-tools"
+            yes | sdkmanager --install "build-tools;35.0.0" > /dev/null
+            APKSIGNER=$(find "$ANDROID_HOME" -type f -name apksigner 2>/dev/null | sort -V | tail -1)
+          fi
+          if [ -z "$APKSIGNER" ]; then
+            echo "::error::Could not locate apksigner even after installing build-tools;35.0.0"
+            exit 1
+          fi
+          echo "Using apksigner: $APKSIGNER"
+
+          VERIFY_OUTPUT=$("$APKSIGNER" verify --verbose --print-certs app/build/outputs/apk/release/app-release.apk)
+          verify_exit=$?
+          echo "$VERIFY_OUTPUT"
+          if [ "$verify_exit" -ne 0 ]; then
+            echo "::error::apksigner verify failed (exit $verify_exit)"
+            exit 1
+          fi
+
+          ACTUAL_SHA256=$(echo "$VERIFY_OUTPUT" | grep "Signer #1 certificate SHA-256 digest" | awk -F': ' '{print $2}' | tr 'A-Z' 'a-z')
+          if [ -z "$ACTUAL_SHA256" ]; then
+            echo "::error::Could not extract signer SHA-256 digest from apksigner output"
+            exit 1
+          fi
+
+          EXPECTED_SHA256=$(echo "$EXPECTED_SIGNER_SHA256" | tr -d ':' | tr 'A-Z' 'a-z')
+          echo "Release APK signer SHA-256: $ACTUAL_SHA256"
+          if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+            echo "::error::Release APK signer SHA-256 ($ACTUAL_SHA256) does not match the expected signing key ($EXPECTED_SHA256)"
+            exit 1
+          fi
+          echo "Release APK signer verified OK"
+
+      - name: Rename APK for release asset
+        run: cp android/app/build/outputs/apk/release/app-release.apk smart-laundry-pos-${{ github.ref_name }}.apk
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            "smart-laundry-pos-${{ github.ref_name }}.apk" \
+            --title "${{ github.ref_name }}" \
+            --generate-notes

--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -125,7 +125,12 @@ jobs:
             exit 1
           fi
 
-          ACTUAL_SHA256=$(echo "$VERIFY_OUTPUT" | grep "Signer #1 certificate SHA-256 digest" | awk -F': ' '{print $2}' | tr 'A-Z' 'a-z')
+          # apksigner's output format varies by build-tools version - older versions print
+          # "Signer #1 certificate SHA-256 digest: ...", newer ones print "V2 Signer:
+          # certificate SHA-256 digest: ..." - match on the common "certificate SHA-256
+          # digest" substring and split on "digest: " rather than the first colon, since
+          # newer output has an earlier colon in the "V2 Signer:" prefix.
+          ACTUAL_SHA256=$(echo "$VERIFY_OUTPUT" | grep -m1 "certificate SHA-256 digest" | awk -F'digest: ' '{print $2}' | tr 'A-Z' 'a-z')
           if [ -z "$ACTUAL_SHA256" ]; then
             echo "::error::Could not extract signer SHA-256 digest from apksigner output"
             exit 1


### PR DESCRIPTION
## Summary

PR #154 was merged before these follow-up fixes landed, so `main`'s "Verify release APK signer" step is currently broken. This PR contains the fixes plus the new tag-triggered release workflow discussed after #154 merged:

- **fix**: the signer-verify step assumed `apksigner` lives under `$ANDROID_HOME/build-tools` and used `set -euo pipefail`, which aborted with no diagnostic the moment that assumption was wrong on the GitHub-hosted runner (confirmed failing: run [30702582041](https://github.com/fahrudina/smart-laundry-pos/actions/runs/30702582041)). Now searches all of `$ANDROID_HOME`, falls back to installing a build-tools package via `sdkmanager` if nothing's found, and uses explicit empty-result checks instead of relying on `pipefail` to surface failures.
- **fix**: the CI runner's `apksigner` (build-tools 37.0.0) prints `V2 Signer: certificate SHA-256 digest: ...` instead of the `Signer #1 certificate SHA-256 digest: ...` format used locally (build-tools 34.0.0) - the old `awk -F': '` pattern split on the wrong colon and extracted nothing (confirmed failing: run [30702795669](https://github.com/fahrudina/smart-laundry-pos/actions/runs/30702795669), correctly failed closed rather than silently passing). Fixed extraction now handles both formats - confirmed passing: run [30702968476](https://github.com/fahrudina/smart-laundry-pos/actions/runs/30702968476), "Release APK signer verified OK".
- **feat**: new `.github/workflows/release-android.yml`, triggered by pushing a `v*.*.*` tag - builds a signed release APK (same key + signer-verification step as `build-android.yml`), with `versionName` derived from the tag itself (`v1.2.3` -> `1.2.3`) rather than the date+run-number scheme used for untagged builds, then publishes it as a GitHub Release asset for that tag.

## Test plan
- [x] `build-android.yml`'s full pipeline (patch version, decode keystore, build debug+release APK, verify signer) passes end-to-end in CI - run [30702968476](https://github.com/fahrudina/smart-laundry-pos/actions/runs/30702968476)
- [ ] Push an actual `v*.*.*` tag to confirm `release-android.yml` builds and publishes a GitHub Release correctly (not yet exercised - its version-from-tag and `gh release create` steps are new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)