### PR TITLE
feat(landing): add Android APK download link, fix release workflow idempotency

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -12,6 +12,11 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing git tag to build and release (e.g. v0.0.1) - for re-running against a tag pushed before a workflow fix'
+        required: true
 
 permissions:
   contents: write
@@ -24,6 +29,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     env:
+      RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
       # Gradle evaluates the whole build.gradle - including the signingConfigs block added
       # by the patch script - during project configuration regardless of which task runs,
       # so these must be visible to the Gradle invocation below.
@@ -34,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -73,9 +81,8 @@ jobs:
 
       - name: Compute release version from tag
         run: |
-          TAG_NAME="${{ github.ref_name }}"
           echo "RELEASE_VERSION_CODE=${{ github.run_number }}" >> "$GITHUB_ENV"
-          echo "RELEASE_VERSION_NAME=${TAG_NAME#v}" >> "$GITHUB_ENV"
+          echo "RELEASE_VERSION_NAME=${RELEASE_TAG#v}" >> "$GITHUB_ENV"
 
       - name: Patch Android version and release signing config
         run: node .github/scripts/patch-android-release-gradle.cjs
@@ -144,14 +151,33 @@ jobs:
           fi
           echo "Release APK signer verified OK"
 
-      - name: Rename APK for release asset
-        run: cp android/app/build/outputs/apk/release/app-release.apk smart-laundry-pos-${{ github.ref_name }}.apk
+      - name: Prepare release APK assets
+        # Two copies: a versioned filename for clarity on the release page, and a
+        # fixed-name alias so external links (e.g. the landing page's download button)
+        # can always point at .../releases/latest/download/smart-laundry-pos-latest.apk
+        # without needing to change every time a new version is tagged.
+        run: |
+          cp android/app/build/outputs/apk/release/app-release.apk "smart-laundry-pos-${RELEASE_TAG}.apk"
+          cp android/app/build/outputs/apk/release/app-release.apk smart-laundry-pos-latest.apk
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
+        # Pushing a tag via GitHub's own "Draft a new release" UI creates the tag and a
+        # Release object together, before this workflow ever runs - `gh release create`
+        # would then fail with "a release with the same tag name already exists". Falls
+        # back to uploading assets onto that existing release instead of erroring.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "${{ github.ref_name }}" \
-            "smart-laundry-pos-${{ github.ref_name }}.apk" \
-            --title "${{ github.ref_name }}" \
-            --generate-notes
+          if gh release view "$RELEASE_TAG" > /dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists - uploading APK assets to it"
+            gh release upload "$RELEASE_TAG" \
+              "smart-laundry-pos-${RELEASE_TAG}.apk" \
+              smart-laundry-pos-latest.apk \
+              --clobber
+          else
+            gh release create "$RELEASE_TAG" \
+              "smart-laundry-pos-${RELEASE_TAG}.apk" \
+              smart-laundry-pos-latest.apk \
+              --title "$RELEASE_TAG" \
+              --generate-notes
+          fi

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -648,6 +648,13 @@ export const LandingPage: React.FC = () => {
                   <Download className="h-4 w-4" />
                   Install Guide
                 </button>
+                <a
+                  href="https://github.com/fahrudina/smart-laundry-pos/releases/latest/download/smart-laundry-pos-latest.apk"
+                  className="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium border border-white/25 rounded-sm hover:bg-white/10 transition-colors"
+                >
+                  <Smartphone className="h-4 w-4" />
+                  Download APK Android
+                </a>
               </div>
               <div className="opacity-80 text-sm">
                 <p className="mb-1">


### PR DESCRIPTION
## Summary
- Landing page footer now has a "Download APK Android" button/link, alongside the existing PWA install and install-guide buttons, pointing at `https://github.com/fahrudina/smart-laundry-pos/releases/latest/download/smart-laundry-pos-latest.apk`.
- `release-android.yml` now uploads a fixed-name `smart-laundry-pos-latest.apk` asset (alongside the tag-versioned `smart-laundry-pos-vX.Y.Z.apk`) so that link keeps resolving correctly release after release, without ever needing to change.
- Fixed a real failure hit on the first actual tag push (`v0.0.1`, run [30703299053](https://github.com/fahrudina/smart-laundry-pos/actions/runs/30703299053)): creating a tag via GitHub's own "Draft a new release" UI creates the tag *and* a Release object together, so `gh release create` collided with an already-existing release ("a release with the same tag name already exists"). Now checks for an existing release first and uploads assets to it instead of erroring.
- Added a `workflow_dispatch` `tag` input so a specific existing tag can be re-run manually (useful for verifying workflow fixes without needing another real tag push).

## Test plan
- [x] `npx tsc` / `npx eslint` on `LandingPage.tsx` - zero errors, zero new lint issues
- [x] Manually dispatched `release-android.yml` against the existing `v0.0.1` tag (run [30703500161](https://github.com/fahrudina/smart-laundry-pos/actions/runs/30703500161)) - passed end-to-end: build, version-from-tag, signing, signer verification, and release asset upload all succeeded
- [x] Confirmed via `gh release view v0.0.1` that both `smart-laundry-pos-latest.apk` and `smart-laundry-pos-v0.0.1.apk` are uploaded
- [x] Confirmed via `curl` that the exact URL used on the landing page (`.../releases/latest/download/smart-laundry-pos-latest.apk`) resolves (302 redirect) to the real uploaded asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)