### PR TITLE
feat(android): switch Google sign-in to native Credential Manager flow

### DIFF
--- a/.github/scripts/patch-android-release-gradle.cjs
+++ b/.github/scripts/patch-android-release-gradle.cjs
@@ -11,7 +11,8 @@
 const fs = require('fs');
 const path = require('path');
 
-const gradlePath = path.join(__dirname, '..', '..', 'android', 'app', 'build.gradle');
+const appGradlePath = path.join(__dirname, '..', '..', 'android', 'app', 'build.gradle');
+const rootGradlePath = path.join(__dirname, '..', '..', 'android', 'build.gradle');
 const versionCode = process.env.RELEASE_VERSION_CODE;
 const versionName = process.env.RELEASE_VERSION_NAME;
 
@@ -20,22 +21,24 @@ if (!versionCode || !versionName) {
   process.exit(1);
 }
 
-let content = fs.readFileSync(gradlePath, 'utf8');
-
-const replace = (from, to) => {
-  if (!content.includes(from)) {
-    console.error(`Expected to find in build.gradle, template may have changed:\n${from}`);
-    process.exit(1);
+const patchFile = (filePath, replacements) => {
+  let content = fs.readFileSync(filePath, 'utf8');
+  for (const [from, to] of replacements) {
+    if (!content.includes(from)) {
+      console.error(`Expected to find in ${filePath}, template may have changed:\n${from}`);
+      process.exit(1);
+    }
+    content = content.replace(from, to);
   }
-  content = content.replace(from, to);
+  fs.writeFileSync(filePath, content);
 };
 
-replace('versionCode 1', `versionCode ${versionCode}`);
-replace('versionName "1.0"', `versionName "${versionName}"`);
-
-replace(
-  'buildTypes {',
-  `signingConfigs {
+patchFile(appGradlePath, [
+  ['versionCode 1', `versionCode ${versionCode}`],
+  ['versionName "1.0"', `versionName "${versionName}"`],
+  [
+    'buildTypes {',
+    `signingConfigs {
         release {
             storeFile file(System.getenv("ANDROID_RELEASE_STORE_FILE"))
             storePassword System.getenv("ANDROID_RELEASE_STORE_PASSWORD")
@@ -43,13 +46,28 @@ replace(
             keyPassword System.getenv("ANDROID_RELEASE_KEY_PASSWORD")
         }
     }
-    buildTypes {`
-);
-
-replace(
-  'release {\n            minifyEnabled false',
-  'release {\n            signingConfig signingConfigs.release\n            minifyEnabled false'
-);
-
-fs.writeFileSync(gradlePath, content);
+    buildTypes {`,
+  ],
+  [
+    'release {\n            minifyEnabled false',
+    'release {\n            signingConfig signingConfigs.release\n            minifyEnabled false',
+  ],
+]);
 console.log(`Patched android/app/build.gradle: versionCode=${versionCode} versionName=${versionName}`);
+
+// @capgo/capacitor-social-login's Apple provider always declares a compileOnly
+// androidx.browser:browser:1.9.0 dependency even when disabled via capacitor.config.ts
+// (compileOnly just means "not bundled", not "removed") - that conflicts with the
+// androidx.browser:browser:1.4.0 pulled in transitively by the (enabled) Google provider's
+// androidbrowserhelper dependency, since AGP enforces the compile and runtime classpaths
+// resolve to the same version. 1.9.0 also requires compileSdk 36 (this project targets 35),
+// so bumping instead of forcing down would mean bumping AGP/compileSdk for every plugin.
+// Forcing the whole build to the already-transitively-used 1.4.0 resolves the conflict
+// without touching compileSdk/AGP.
+patchFile(rootGradlePath, [
+  [
+    'allprojects {\n    repositories {\n        google()\n        mavenCentral()\n    }\n}',
+    'allprojects {\n    repositories {\n        google()\n        mavenCentral()\n    }\n    configurations.all {\n        resolutionStrategy.force \'androidx.browser:browser:1.4.0\'\n    }\n}',
+  ],
+]);
+console.log('Patched android/build.gradle: forced androidx.browser:browser to 1.4.0');

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -12,6 +12,17 @@ const config: CapacitorConfig = {
       backgroundColor: '#2563eb',
       androidScaleType: 'CENTER_CROP',
     },
+    // Only Google sign-in is used natively - excludes the other providers'
+    // native SDKs from the APK (see @capgo/capacitor-social-login's
+    // capacitor:sync:before script, which reads this on every `cap sync`).
+    SocialLogin: {
+      providers: {
+        google: true,
+        facebook: false,
+        apple: false,
+        twitter: false,
+      },
+    },
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@capacitor/core": "^7.4.3",
         "@capacitor/splash-screen": "^7.0.5",
         "@capacitor/status-bar": "^7.0.6",
+        "@capgo/capacitor-social-login": "^7.20.0",
         "@hookform/resolvers": "^3.9.0",
         "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.1",
@@ -264,6 +265,15 @@
       "resolved": "https://registry.npmjs.org/@capacitor/status-bar/-/status-bar-7.0.6.tgz",
       "integrity": "sha512-7AVqj46b26QikImQzWfsJmzG8NUJZBGkrVSuoeTo+SX/YH3hXH0MqwwFgMqMGHfa/BICDgSvTjM9miVFlq0+RQ==",
       "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=7.0.0"
+      }
+    },
+    "node_modules/@capgo/capacitor-social-login": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@capgo/capacitor-social-login/-/capacitor-social-login-7.20.0.tgz",
+      "integrity": "sha512-rHlEALFUonLe4sDG+qybDowh2/XDiHJ4DK9pShe1aPTGSrmA5j7kz8VbHYGqgof5xdyeC7pAY3+8PASTW+qGKg==",
+      "license": "MPL-2.0",
       "peerDependencies": {
         "@capacitor/core": ">=7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@capacitor/core": "^7.4.3",
     "@capacitor/splash-screen": "^7.0.5",
     "@capacitor/status-bar": "^7.0.6",
+    "@capgo/capacitor-social-login": "^7.20.0",
     "@hookform/resolvers": "^3.9.0",
     "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.1",

--- a/src/components/auth/GoogleLoginButton.tsx
+++ b/src/components/auth/GoogleLoginButton.tsx
@@ -22,11 +22,16 @@ const GoogleDivider: React.FC = () => (
 );
 
 /**
- * Native (Android/iOS) Google button. The web GSI script (@react-oauth/google) never
+ * Native (Android) Google button. The web GSI script (@react-oauth/google) never
  * renders inside the Capacitor WebView: it validates window.location.origin
  * (https://localhost there) against the OAuth client's Authorized JavaScript Origins,
  * and Google also actively blocks GSI/OAuth flows detected running inside embedded
  * WebViews. Native Credential Manager sign-in sidesteps both problems.
+ *
+ * Android only: @capgo/capacitor-social-login also requires a separate iOSClientId
+ * for iOS, which this project doesn't have configured (there's no iOS platform set
+ * up at all yet). Routing iOS through this flow would fail silently, so it falls
+ * back to WebGoogleLoginButton until iOS support is actually added.
  */
 const NativeGoogleLoginButton: React.FC = () => {
   const { signInWithGoogle } = useAuth();
@@ -61,10 +66,14 @@ const NativeGoogleLoginButton: React.FC = () => {
         return;
       }
 
-      await signInWithGoogle(result.idToken);
-    } catch {
-      // Error toast handled in AuthContext for signInWithGoogle failures; this catch
-      // also covers SocialLogin.initialize/login rejecting (e.g. user cancelled).
+      try {
+        await signInWithGoogle(result.idToken);
+      } catch {
+        // Error toast already shown by AuthContext for signInWithGoogle failures.
+      }
+    } catch (error) {
+      // Covers SocialLogin.initialize/login rejecting (e.g. user cancelled, plugin error).
+      console.error('Native Google sign-in failed', error);
       toast({ title: 'Error', description: 'Gagal masuk dengan Google', variant: 'destructive' });
     }
   };
@@ -133,5 +142,5 @@ export const GoogleLoginButton: React.FC = () => {
     return null;
   }
 
-  return Capacitor.isNativePlatform() ? <NativeGoogleLoginButton /> : <WebGoogleLoginButton />;
+  return Capacitor.getPlatform() === 'android' ? <NativeGoogleLoginButton /> : <WebGoogleLoginButton />;
 };

--- a/src/components/auth/GoogleLoginButton.tsx
+++ b/src/components/auth/GoogleLoginButton.tsx
@@ -1,35 +1,88 @@
 import React from 'react';
+import { Capacitor } from '@capacitor/core';
 import { GoogleOAuthProvider, GoogleLogin } from '@react-oauth/google';
+import { SocialLogin } from '@capgo/capacitor-social-login';
+import { Button } from '@/components/ui/button';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
 
 const GOOGLE_CLIENT_ID = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined;
 
+let nativeGoogleInitialized = false;
+
+const GoogleDivider: React.FC = () => (
+  <div className="relative">
+    <div className="absolute inset-0 flex items-center">
+      <span className="w-full border-t border-gray-200" />
+    </div>
+    <div className="relative flex justify-center text-xs uppercase">
+      <span className="bg-white px-2 text-gray-400">atau</span>
+    </div>
+  </div>
+);
+
 /**
- * Google Sign-In button. Renders a divider + Google button.
- * No-op (renders nothing) when VITE_GOOGLE_CLIENT_ID is not configured, so the
- * app works unchanged in environments without Google OAuth set up.
+ * Native (Android/iOS) Google button. The web GSI script (@react-oauth/google) never
+ * renders inside the Capacitor WebView: it validates window.location.origin
+ * (https://localhost there) against the OAuth client's Authorized JavaScript Origins,
+ * and Google also actively blocks GSI/OAuth flows detected running inside embedded
+ * WebViews. Native Credential Manager sign-in sidesteps both problems.
  */
-export const GoogleLoginButton: React.FC = () => {
+const NativeGoogleLoginButton: React.FC = () => {
   const { signInWithGoogle } = useAuth();
   const { toast } = useToast();
 
-  if (!GOOGLE_CLIENT_ID) {
-    return null;
-  }
+  const handlePress = async () => {
+    try {
+      if (!nativeGoogleInitialized) {
+        await SocialLogin.initialize({
+          google: { webClientId: GOOGLE_CLIENT_ID },
+        });
+        nativeGoogleInitialized = true;
+      }
+
+      const { result } = await SocialLogin.login({
+        provider: 'google',
+        options: { scopes: ['email', 'profile'] },
+      });
+
+      if (result.responseType !== 'online') {
+        toast({ title: 'Error', description: 'Tidak ada kredensial dari Google', variant: 'destructive' });
+        return;
+      }
+      if (!result.idToken) {
+        toast({ title: 'Error', description: 'Tidak ada kredensial dari Google', variant: 'destructive' });
+        return;
+      }
+
+      await signInWithGoogle(result.idToken);
+    } catch {
+      // Error toast handled in AuthContext for signInWithGoogle failures; this catch
+      // also covers SocialLogin.initialize/login rejecting (e.g. user cancelled).
+      toast({ title: 'Error', description: 'Gagal masuk dengan Google', variant: 'destructive' });
+    }
+  };
 
   return (
-    <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID}>
-      <div className="mt-6">
-        <div className="relative">
-          <div className="absolute inset-0 flex items-center">
-            <span className="w-full border-t border-gray-200" />
-          </div>
-          <div className="relative flex justify-center text-xs uppercase">
-            <span className="bg-white px-2 text-gray-400">atau</span>
-          </div>
-        </div>
+    <div className="mt-6">
+      <GoogleDivider />
+      <div className="mt-4 flex justify-center">
+        <Button type="button" variant="outline" className="w-[320px] max-w-full" onClick={handlePress}>
+          Lanjutkan dengan Google
+        </Button>
+      </div>
+    </div>
+  );
+};
 
+const WebGoogleLoginButton: React.FC = () => {
+  const { signInWithGoogle } = useAuth();
+  const { toast } = useToast();
+
+  return (
+    <GoogleOAuthProvider clientId={GOOGLE_CLIENT_ID as string}>
+      <div className="mt-6">
+        <GoogleDivider />
         <div className="mt-4 flex justify-center">
           <GoogleLogin
             onSuccess={async (credentialResponse) => {
@@ -62,4 +115,17 @@ export const GoogleLoginButton: React.FC = () => {
       </div>
     </GoogleOAuthProvider>
   );
+};
+
+/**
+ * Google Sign-In button. Renders a divider + Google button.
+ * No-op (renders nothing) when VITE_GOOGLE_CLIENT_ID is not configured, so the
+ * app works unchanged in environments without Google OAuth set up.
+ */
+export const GoogleLoginButton: React.FC = () => {
+  if (!GOOGLE_CLIENT_ID) {
+    return null;
+  }
+
+  return Capacitor.isNativePlatform() ? <NativeGoogleLoginButton /> : <WebGoogleLoginButton />;
 };

--- a/src/components/auth/GoogleLoginButton.tsx
+++ b/src/components/auth/GoogleLoginButton.tsx
@@ -41,9 +41,15 @@ const NativeGoogleLoginButton: React.FC = () => {
         nativeGoogleInitialized = true;
       }
 
+      // Don't pass a custom `scopes` option here: the plugin's Android side hard-rejects
+      // any login() call with custom scopes unless MainActivity implements
+      // ModifiedMainActivityForSocialLoginPlugin ("You CANNOT use scopes without
+      // modifying the main activity"). It already requests userinfo.email,
+      // userinfo.profile, and openid as default scopes regardless, which is all
+      // signInWithGoogle needs from the ID token.
       const { result } = await SocialLogin.login({
         provider: 'google',
-        options: { scopes: ['email', 'profile'] },
+        options: {},
       });
 
       if (result.responseType !== 'online') {


### PR DESCRIPTION
## Summary

- The web Google Identity Services (GSI) button never actually renders inside the packaged Android app: GSI validates `window.location.origin` (`https://localhost` there, per Capacitor's default WebView origin) against the OAuth client's Authorized JavaScript Origins in Google Cloud Console, and separately, Google actively blocks GSI/OAuth flows detected running inside embedded WebViews (`disallowed_useragent`) as an anti-phishing measure. Neither is fixable by patching the web flow itself.
- Android now uses [`@capgo/capacitor-social-login`](https://github.com/Cap-go/capacitor-social-login)'s native Credential Manager integration instead (Google's current recommended API, not the deprecated legacy Sign-In SDK). It returns the same kind of Google ID token JWT, so it's fed into the existing `signInWithGoogle()` unchanged — no backend/RPC changes.
- Web and installed-PWA sign-in are untouched; `GoogleLoginButton.tsx` now just branches on `Capacitor.isNativePlatform()`.
- `capacitor.config.ts` disables the plugin's unused Facebook/Apple/Twitter providers so only Google's native SDK gets bundled into the APK.
- `.github/scripts/patch-android-release-gradle.cjs` now also patches the generated root `android/build.gradle` to force `androidx.browser:browser` to `1.4.0`. Found via a real local build: the plugin's Apple provider still declares a conflicting `1.9.0` `compileOnly` dependency even when disabled (`compileOnly` demotes it, it doesn't remove it), which breaks the build once AGP's compile/runtime consistent-resolution check kicks in — enabling Apple instead is worse, since `1.9.0` itself requires compileSdk 36 / AGP 8.9.1 (this project is on 35 / 8.7.2).

## ⚠️ Manual step required before this works on a real device

Google Cloud Console needs a new **Android**-type OAuth client in the same project as the existing Web client:
- Package name: `com.smartlaundry.pos`
- SHA-1: the release keystore's signing certificate fingerprint (`keytool -list -v -keystore <release.keystore> -alias <alias> -storepass <password> | grep SHA1`)

The existing Web client ID stays exactly as-is in code/CI (`VITE_GOOGLE_CLIENT_ID`) — it's reused as `webClientId` for the native flow too. No new secrets or CI changes needed.

## Test plan

- [x] `npx tsc -p tsconfig.app.json --noEmit` — zero new errors (2 pre-existing unrelated baseline errors only)
- [x] `npx eslint` on all touched files — zero issues
- [x] `npm run build` — succeeds
- [x] Regenerated `android/` fresh (`cap add android && cap sync android`, matching CI's exact order) and ran a real `./gradlew assembleDebug` via the actual patch script — `BUILD SUCCESSFUL`
- [x] Inspected the built debug APK: confirmed Google/Credential Manager resources bundled (`common_google_signin_btn_*`, `androidx.credentials_credentials.version`, `googleid.properties`), confirmed no Facebook assets leaked in
- [ ] Register the Android OAuth client in Google Cloud Console (see above — manual, outside CI)
- [ ] Trigger `build-android.yml`/`release-android.yml` for a signed build and sideload-test the native Google button on a real device

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Google sign-in for Android and iOS.
  * Google authentication now uses the appropriate sign-in experience across mobile and web platforms.
* **Improvements**
  * Improved handling of sign-in errors with clearer in-app notifications.
  * Updated mobile authentication support for more reliable Google login setup and release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->