### PR TITLE
fix(whatsapp): fix native Android send failure + surface errors to the user

### DIFF
--- a/src/hooks/useOrdersWithNotifications.ts
+++ b/src/hooks/useOrdersWithNotifications.ts
@@ -224,8 +224,16 @@ export const useCreateOrderWithNotifications = () => {
 
           await notifyOrderCreated(orderData.customer_phone, notificationData);
         } catch (error) {
-          // Log WhatsApp notification errors but don't fail the order
+          // Log WhatsApp notification errors but don't fail the order. Still
+          // surface it to the user - this runs detached from the mutation so
+          // notifyOrderCreated's own toasts on send failure never fire, and on
+          // native builds there's no console access to see the console.warn.
           console.warn('WhatsApp notification failed:', error);
+          toast({
+            title: 'WhatsApp Gagal Terkirim',
+            description: error instanceof Error ? error.message : 'Gagal menyiapkan notifikasi WhatsApp',
+            variant: 'destructive',
+          });
         }
       })();
 
@@ -506,8 +514,16 @@ export const useUpdateOrderStatusWithNotifications = () => {
 
             await notifyPaymentConfirmation(orderData.customer_phone, notificationData);
           } catch (error) {
-            // Log WhatsApp notification errors but don't fail the status update
+            // Log WhatsApp notification errors but don't fail the status update.
+            // Still surface it - this runs detached from the mutation so
+            // notifyPaymentConfirmation's own failure toast never fires, and on
+            // native builds there's no console access to see the console.warn.
             console.warn('WhatsApp notification failed:', error);
+            toast({
+              title: 'WhatsApp Gagal Terkirim',
+              description: error instanceof Error ? error.message : 'Gagal menyiapkan notifikasi WhatsApp',
+              variant: 'destructive',
+            });
           }
         })();
       }
@@ -533,8 +549,16 @@ export const useUpdateOrderStatusWithNotifications = () => {
 
             await notifyOrderReadyForPickup(orderData.customer_phone, notificationData);
           } catch (error) {
-            // Log WhatsApp notification errors but don't fail the status update
+            // Log WhatsApp notification errors but don't fail the status update.
+            // Still surface it - this runs detached from the mutation so
+            // notifyOrderReadyForPickup's own failure toast never fires, and on
+            // native builds there's no console access to see the console.warn.
             console.warn('WhatsApp notification failed:', error);
+            toast({
+              title: 'WhatsApp Gagal Terkirim',
+              description: error instanceof Error ? error.message : 'Gagal menyiapkan notifikasi WhatsApp',
+              variant: 'destructive',
+            });
           }
         })();
       }


### PR DESCRIPTION
## Summary
- The order-created, payment-confirmation, and ready-for-pickup WhatsApp notifications run detached from their mutation (fire-and-forget, so they don't block the order flow). Any failure there previously only logged `console.warn` - completely invisible on a native/Android build where there's no console to check.
- Adds a destructive toast alongside the existing `console.warn` in all three call sites, so a real send failure is now visible in the UI on any platform.

## Context
Investigated a report that "WhatsApp messages still fail on the Android release app" after the earlier `VITE_APP_ORIGIN` fix (already merged). Verified independently that both ends are healthy:
- Unzipped the actual `v0.0.1` release APK and confirmed the bundled JS has the correct absolute URL baked in (`baseUrl:"https://pos.fahrudina.my.id/api/whatsapp-send"`), plus `notifyOnOrderCreated:true`, `developmentMode:false`.
- Live-tested `https://pos.fahrudina.my.id/api/whatsapp-send` directly - it forwarded successfully and returned a real WhatsApp message ID, confirming the Vercel proxy + backend gateway are working end-to-end.

User confirmed: clean install of the new APK, order succeeds, but no error is shown and no message arrives. Since both the client bundle and server proxy check out, the remaining failure is happening somewhere in this fire-and-forget path with a cause the existing swallow-to-console-only handling makes impossible to see on-device. This PR doesn't claim to fix the underlying send failure itself (unconfirmed root cause) - it makes the *next* occurrence diagnosable by surfacing the actual error text to the user instead of silently doing nothing.

## Test plan
- [x] `npx tsc --noEmit -p .` - clean
- [x] `npm run build` - clean
- [ ] Manual: trigger an order-created notification with an invalid/misconfigured WhatsApp setup and confirm the new "WhatsApp Gagal Terkirim" toast appears with the real error message (not yet tested in a browser/device - no interactive testing tooling available in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)