### PR TITLE
fix(whatsapp): fix Vercel-function URL detection for absolute base URLs

### DIFF
--- a/src/integrations/whatsapp/client.ts
+++ b/src/integrations/whatsapp/client.ts
@@ -24,6 +24,28 @@ const parseNativeBody = (data: unknown): WhatsAppResponse => {
   return { success: true, message: 'Message sent successfully', id: 'unknown' };
 };
 
+// baseUrl is a same-origin relative path ('/api/whatsapp-send') on the web
+// deployment, but an absolute URL ('https://.../api/whatsapp-send') on native
+// builds, which bake in VITE_APP_ORIGIN (see whatsapp-config.ts) since the
+// packaged app's WebView has no same-origin backend to resolve a relative
+// path against. Checking only the string prefix misses the absolute case -
+// it starts with "https://", not "/api/" - so this resolves the actual path,
+// whichever form baseUrl takes. Matches only the specific serverless-function
+// path (not just any "/api/" prefix), so it doesn't collide with the local
+// dev proxy's '/api/whatsapp' base URL, which is a distinct case below.
+const isVercelFunctionUrl = (baseUrl: string): boolean => {
+  const path = baseUrl.startsWith('/')
+    ? baseUrl
+    : (() => {
+        try {
+          return new URL(baseUrl).pathname;
+        } catch {
+          return '';
+        }
+      })();
+  return path.startsWith('/api/whatsapp-send');
+};
+
 /**
  * WhatsApp API Client
  * Handles communication with the WhatsApp messaging service
@@ -62,7 +84,7 @@ export class WhatsAppClient {
 
       // Determine if we're using local proxy, Vercel serverless function, or direct API
       const isUsingLocalProxy = this.config.baseUrl.includes('localhost') && this.config.baseUrl.includes('/api/whatsapp');
-      const isUsingVercelFunction = this.config.baseUrl.startsWith('/api/');
+      const isUsingVercelFunction = isVercelFunctionUrl(this.config.baseUrl);
 
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',
@@ -180,7 +202,7 @@ export class WhatsAppClient {
 
       // Determine if we're using local proxy, Vercel serverless function, or direct API
       const isUsingLocalProxy = this.config.baseUrl.includes('localhost') && this.config.baseUrl.includes('/api/whatsapp');
-      const isUsingVercelFunction = this.config.baseUrl.startsWith('/api/');
+      const isUsingVercelFunction = isVercelFunctionUrl(this.config.baseUrl);
 
       const headers: Record<string, string> = {
         'Content-Type': 'application/json',

--- a/src/integrations/whatsapp/client.ts
+++ b/src/integrations/whatsapp/client.ts
@@ -28,22 +28,20 @@ const parseNativeBody = (data: unknown): WhatsAppResponse => {
 // deployment, but an absolute URL ('https://.../api/whatsapp-send') on native
 // builds, which bake in VITE_APP_ORIGIN (see whatsapp-config.ts) since the
 // packaged app's WebView has no same-origin backend to resolve a relative
-// path against. Checking only the string prefix misses the absolute case -
-// it starts with "https://", not "/api/" - so this resolves the actual path,
-// whichever form baseUrl takes. Matches only the specific serverless-function
-// path (not just any "/api/" prefix), so it doesn't collide with the local
-// dev proxy's '/api/whatsapp' base URL, which is a distinct case below.
+// path against. Resolving against a dummy base handles both forms uniformly
+// (the base is ignored when baseUrl is already absolute) and normalizes dot
+// segments. Compares the pathname exactly (not a prefix) so it doesn't
+// false-match '/api/whatsapp-sender', '/api/whatsapp-send-message', a
+// sub-path, or the local dev proxy's distinct '/api/whatsapp' base URL.
 const isVercelFunctionUrl = (baseUrl: string): boolean => {
-  const path = baseUrl.startsWith('/')
-    ? baseUrl
-    : (() => {
-        try {
-          return new URL(baseUrl).pathname;
-        } catch {
-          return '';
-        }
-      })();
-  return path.startsWith('/api/whatsapp-send');
+  let pathname: string;
+  try {
+    pathname = new URL(baseUrl, 'http://localhost/').pathname;
+  } catch {
+    return false;
+  }
+  const normalized = pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+  return normalized === '/api/whatsapp-send';
 };
 
 /**


### PR DESCRIPTION
## Summary
Follow-up to #158/#159 - you reported the native app now got past "Failed to fetch" but hit **HTTP 405** instead.

Root cause: `isUsingVercelFunction` detects the Vercel serverless-function proxy via `baseUrl.startsWith('/api/')`. That only holds for the web deployment's relative `baseUrl` (`/api/whatsapp-send`). Native builds bake in an **absolute** `baseUrl` instead (`VITE_APP_ORIGIN` + path - see `whatsapp-config.ts`), so the check always evaluated `false` there. The client then treated it as a direct WhatsApp-API base and appended `/send-message`, producing `https://pos.fahrudina.my.id/api/whatsapp-send/send-message` - a path that doesn't match the real function. Vercel's SPA catch-all rewrite serves the static `index.html` for that unmatched path, and Vercel returns 405 for a POST to a static asset (confirmed live - the 405 response has `content-disposition: inline; filename="index.html"`).

`isVercelFunctionUrl` now resolves the URL's actual path (parsing it as absolute when it isn't already a relative `/`-prefixed one) instead of a raw string prefix check, so it correctly recognizes the Vercel function regardless of which form `baseUrl` takes. Kept it scoped to `/api/whatsapp-send` specifically (not any `/api/` path) so it doesn't collide with the local dev proxy's `/api/whatsapp` base URL, which is a distinct, pre-existing case.

## Verification
Before creating this PR, reconstructed the exact endpoint the fixed client computes for the real production `baseUrl` and hit it live:
- Old logic's endpoint (`.../api/whatsapp-send/send-message`) → confirmed **405**, static `index.html` response.
- Fixed logic's endpoint (`.../api/whatsapp-send`) → confirmed **200**, real WhatsApp message ID returned.

Also confirmed the local dev proxy case (`http://localhost:8080/api/whatsapp`) and the direct-API case still resolve to their original, correct endpoints (unit-checked in isolation, not just by inspection).

## Related (not fixed here)
`src/integrations/whatsapp/sender-client.ts` (WhatsApp sender registration in Store Settings) has the same underlying class of bug in a different form - it fetches a bare relative `/api/wa-sender-register` with no `VITE_APP_ORIGIN` prefix at all, so it would always fail on native builds. Separate feature (sender registration, not order notifications), left out of this PR to keep the fix scoped - worth a fast follow-up.

## Test plan
- [x] `npx tsc --noEmit -p .` - clean
- [x] `npm run build` - clean, including a build with the exact Android CI env vars to confirm the minified bundle bakes in the fixed logic
- [x] Live-verified the exact computed endpoint against production - 200 with a real message ID
- [ ] Manual: verify on a real device with the next release APK that the WhatsApp notification actually arrives (not yet tested - no device/interactive testing tooling available in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WhatsApp message sending and connection testing across hosted and local environments.
  * Prevented unrelated API routes from being incorrectly treated as WhatsApp serverless endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->