### PR TITLE
fix(ui): keep dialogs clear of Android status bar and short viewports

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="id">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Smart Laundry POS - Sistem Kasir Modern untuk Laundry Indonesia</title>
     <meta name="description" content="Sistem Point of Sale (POS) modern untuk bisnis laundry di Indonesia. Kelola pesanan, pelanggan, dan pembayaran dengan mudah. Aplikasi mobile, cloud-based, dan bisa diinstall seperti aplikasi native. Kontak: fahrudinjaya@gmail.com" />
     <meta name="keywords" content="sistem kasir laundry, POS laundry Indonesia, aplikasi laundry, manajemen laundry, kasir digital laundry, software laundry, sistem laundry online, kasir laundry mobile, aplikasi kasir laundry android" />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg max-h-[90vh] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto border bg-background p-6 pt-[max(1.5rem,env(safe-area-inset-top))] pb-[max(1.5rem,env(safe-area-inset-bottom))] shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Order success dialog (and every other `Dialog`) could visually overlap the Android status bar / gesture nav on native builds, and could overflow short mobile viewports with no way to scroll to the action buttons.
- Root cause: `main.tsx` sets `StatusBar.setOverlaysWebView({ overlay: true })`, so the WebView renders full-screen under system chrome, but `index.html` was missing `viewport-fit=cover` (required for `env(safe-area-inset-*)` to resolve) and the shared `DialogContent` primitive (`src/components/ui/dialog.tsx`) had no safe-area padding or height clamp — unlike `AppLayout`/`MobileBottomNav`/`Sheet`, which already handle this.
- Fixed at the shared `Dialog` primitive level rather than per-dialog, since the gap affected every dialog in the app, not just `OrderSuccessDialog`:
  - `index.html`: added `viewport-fit=cover` to the viewport meta tag.
  - `src/components/ui/dialog.tsx`: `DialogContent` now defaults to `max-h-[90vh] overflow-y-auto` plus safe-area-aware `pt`/`pb` (`max(1.5rem, env(safe-area-inset-*))`).
- Six dialogs that already set their own `max-h-[90vh] overflow-y-auto` are unaffected (identical values win via `tailwind-merge`); `OrderSuccessDialog` and `ThermalPrintDialog` — the two that lacked it — now inherit it for free with no per-file changes needed.

## Test plan
- [x] `npx tsc -p tsconfig.app.json --noEmit` — only pre-existing, unrelated baseline errors
- [x] `npm run build` — succeeds
- [ ] Sideload-test on a real Android device: confirm the order success dialog (and a couple of other dialogs) no longer collide with the status bar, and that a short device can scroll to the action buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)