### PR TITLE
Mobile UX redesign: Service, Customer, Staff management

### DIFF
--- a/src/components/layout/MobilePageHeader.tsx
+++ b/src/components/layout/MobilePageHeader.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ArrowLeft } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface MobilePageHeaderProps {
+  title: string;
+  onBack: () => void;
+  trailing?: React.ReactNode;
+  className?: string;
+}
+
+export const MobilePageHeader: React.FC<MobilePageHeaderProps> = ({
+  title,
+  onBack,
+  trailing,
+  className,
+}) => {
+  return (
+    <div className={cn('-mx-4 mb-4 flex items-center gap-2 border-b bg-background px-4 py-3', className)}>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={onBack}
+        aria-label="Kembali"
+        className="h-9 w-9 flex-shrink-0"
+      >
+        <ArrowLeft className="h-5 w-5" />
+      </Button>
+      <h1 className="min-w-0 flex-1 truncate text-lg font-semibold">{title}</h1>
+      {trailing && <div className="flex-shrink-0">{trailing}</div>}
+    </div>
+  );
+};

--- a/src/components/pos/AddCustomerDialog.tsx
+++ b/src/components/pos/AddCustomerDialog.tsx
@@ -1,11 +1,14 @@
 import { useState } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { UserPlus } from 'lucide-react';
 import { useCustomers } from '@/hooks/useCustomers';
 import { useToast } from '@/hooks/use-toast';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
 
 interface AddCustomerDialogProps {
   onCustomerAdded?: (customer: any) => void;
@@ -13,6 +16,13 @@ interface AddCustomerDialogProps {
 }
 
 export const AddCustomerDialog = ({ onCustomerAdded, trigger }: AddCustomerDialogProps) => {
+  const isMobile = useIsMobile();
+  const Root = isMobile ? Drawer : Dialog;
+  const Trigger = isMobile ? DrawerTrigger : DialogTrigger;
+  const Content = isMobile ? DrawerContent : DialogContent;
+  const Header = isMobile ? DrawerHeader : DialogHeader;
+  const Title = isMobile ? DrawerTitle : DialogTitle;
+
   const [open, setOpen] = useState(false);
   const [formData, setFormData] = useState({
     name: '',
@@ -61,20 +71,26 @@ export const AddCustomerDialog = ({ onCustomerAdded, trigger }: AddCustomerDialo
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>
+    <Root open={open} onOpenChange={setOpen} {...(isMobile ? { shouldScaleBackground: false } : {})}>
+      <Trigger asChild>
         {trigger || (
           <Button variant="outline" className="gap-2">
             <UserPlus className="h-4 w-4" />
             Tambah Pelanggan Baru
           </Button>
         )}
-      </DialogTrigger>
-      <DialogContent className="w-[95vw] max-w-[425px] max-h-[90vh] overflow-y-auto mx-4 my-8">
-        <DialogHeader>
-          <DialogTitle className="text-lg sm:text-xl">Tambah Pelanggan Baru</DialogTitle>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4 pb-2">
+      </Trigger>
+      <Content className={isMobile ? 'flex max-h-[85vh] flex-col' : 'w-[95vw] max-w-[425px] max-h-[90vh] overflow-y-auto mx-4 my-8'}>
+        <Header>
+          <Title className="text-lg sm:text-xl">Tambah Pelanggan Baru</Title>
+        </Header>
+        <form
+          onSubmit={handleSubmit}
+          className={cn(
+            'space-y-4 pb-2',
+            isMobile && 'min-h-0 flex-1 overflow-y-auto px-4 pb-[max(1rem,env(safe-area-inset-bottom))]'
+          )}
+        >
           <div className="space-y-2">
             <Label htmlFor="name" className="text-sm font-medium">Nama *</Label>
             <Input
@@ -141,7 +157,7 @@ export const AddCustomerDialog = ({ onCustomerAdded, trigger }: AddCustomerDialo
             </Button>
           </div>
         </form>
-      </DialogContent>
-    </Dialog>
+      </Content>
+    </Root>
   );
 };

--- a/src/components/pos/AddCustomerDialog.tsx
+++ b/src/components/pos/AddCustomerDialog.tsx
@@ -1,17 +1,17 @@
 import { useState } from 'react';
+import { UserPlus } from 'lucide-react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { UserPlus } from 'lucide-react';
-import { useCustomers } from '@/hooks/useCustomers';
+import { useCustomers, type Customer } from '@/hooks/useCustomers';
 import { useToast } from '@/hooks/use-toast';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
 
 interface AddCustomerDialogProps {
-  onCustomerAdded?: (customer: any) => void;
+  onCustomerAdded?: (customer: Customer) => void;
   trigger?: React.ReactNode;
 }
 

--- a/src/components/pos/EditCustomerDialog.tsx
+++ b/src/components/pos/EditCustomerDialog.tsx
@@ -1,11 +1,14 @@
 import { useState, useEffect } from 'react';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerDescription } from '@/components/ui/drawer';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 import { useStore } from '@/contexts/StoreContext';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
 
 interface Customer {
   id: string;
@@ -31,6 +34,13 @@ export const EditCustomerDialog = ({
   onOpenChange,
   onCustomerUpdated 
 }: EditCustomerDialogProps) => {
+  const isMobile = useIsMobile();
+  const Root = isMobile ? Drawer : Dialog;
+  const Content = isMobile ? DrawerContent : DialogContent;
+  const Header = isMobile ? DrawerHeader : DialogHeader;
+  const Title = isMobile ? DrawerTitle : DialogTitle;
+  const Description = isMobile ? DrawerDescription : DialogDescription;
+
   const [formData, setFormData] = useState({
     name: '',
     phone: '',
@@ -106,15 +116,21 @@ export const EditCustomerDialog = ({
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="w-[95vw] max-w-[425px] max-h-[90vh] overflow-y-auto mx-4 my-8">
-        <DialogHeader>
-          <DialogTitle className="text-lg sm:text-xl">Edit Customer</DialogTitle>
-          <DialogDescription>
+    <Root open={open} onOpenChange={onOpenChange} {...(isMobile ? { shouldScaleBackground: false } : {})}>
+      <Content className={isMobile ? 'flex max-h-[85vh] flex-col' : 'w-[95vw] max-w-[425px] max-h-[90vh] overflow-y-auto mx-4 my-8'}>
+        <Header>
+          <Title className="text-lg sm:text-xl">Edit Customer</Title>
+          <Description>
             Update customer information
-          </DialogDescription>
-        </DialogHeader>
-        <form onSubmit={handleSubmit} className="space-y-4 pb-2">
+          </Description>
+        </Header>
+        <form
+          onSubmit={handleSubmit}
+          className={cn(
+            'space-y-4 pb-2',
+            isMobile && 'min-h-0 flex-1 overflow-y-auto px-4 pb-[max(1rem,env(safe-area-inset-bottom))]'
+          )}
+        >
           <div className="space-y-2">
             <Label htmlFor="edit-name" className="text-sm font-medium">Name *</Label>
             <Input
@@ -181,7 +197,7 @@ export const EditCustomerDialog = ({
             </Button>
           </div>
         </form>
-      </DialogContent>
-    </Dialog>
+      </Content>
+    </Root>
   );
 };

--- a/src/components/stores/StoreStaffManagement.tsx
+++ b/src/components/stores/StoreStaffManagement.tsx
@@ -5,10 +5,13 @@ import { Badge } from '@/components/ui/badge';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { supabase } from '@/integrations/supabase/client';
 import { authService } from '@/services/authService';
 import { useToast } from '@/hooks/use-toast';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
 import { Users, UserPlus, Mail, Phone, Calendar } from 'lucide-react';
 import { StoreWithOwnershipInfo } from '@/types/multi-tenant';
 
@@ -35,6 +38,13 @@ interface CreateStaffForm {
 }
 
 export const StoreStaffManagement: React.FC<StoreStaffManagementProps> = ({ store }) => {
+  const isMobile = useIsMobile();
+  const DialogRoot = isMobile ? Drawer : Dialog;
+  const DialogTriggerEl = isMobile ? DrawerTrigger : DialogTrigger;
+  const DialogContentEl = isMobile ? DrawerContent : DialogContent;
+  const DialogHeaderEl = isMobile ? DrawerHeader : DialogHeader;
+  const DialogTitleEl = isMobile ? DrawerTitle : DialogTitle;
+
   const [staff, setStaff] = useState<StaffMember[]>([]);
   const [unassignedStaff, setUnassignedStaff] = useState<StaffMember[]>([]);
   const [loading, setLoading] = useState(false);
@@ -188,23 +198,34 @@ export const StoreStaffManagement: React.FC<StoreStaffManagementProps> = ({ stor
   return (
     <Card>
       <CardHeader>
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className={cn('flex flex-col gap-3', !isMobile && 'sm:flex-row sm:items-center sm:justify-between')}>
           <CardTitle className="flex min-w-0 items-center gap-2 text-lg sm:text-2xl">
             <Users className="h-5 w-5 flex-shrink-0" />
-            <span className="truncate">Manajemen Staf - {store.store_name}</span>
+            <span className="truncate">
+              {isMobile ? 'Anggota Staf' : `Manajemen Staf - ${store.store_name}`}
+            </span>
           </CardTitle>
-          <div className="grid grid-cols-1 gap-2 sm:flex sm:flex-shrink-0 sm:flex-wrap">
-            <Dialog open={assignDialogOpen} onOpenChange={setAssignDialogOpen}>
-              <DialogTrigger asChild>
-                <Button variant="outline" size="sm" className="w-full sm:w-auto">
-                  Tugaskan yang Ada
+          <div className={cn('grid grid-cols-2 gap-2', !isMobile && 'sm:flex sm:flex-shrink-0 sm:flex-wrap')}>
+            <DialogRoot open={assignDialogOpen} onOpenChange={setAssignDialogOpen} {...(isMobile ? { shouldScaleBackground: false } : {})}>
+              <DialogTriggerEl asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className={cn('w-full', isMobile ? 'px-2 text-xs' : 'sm:w-auto')}
+                >
+                  {isMobile ? 'Tugaskan' : 'Tugaskan yang Ada'}
                 </Button>
-              </DialogTrigger>
-              <DialogContent className="max-w-lg">
-                <DialogHeader>
-                  <DialogTitle>Tugaskan Staf yang Ada</DialogTitle>
-                </DialogHeader>
-                <div className="space-y-4">
+              </DialogTriggerEl>
+              <DialogContentEl className={isMobile ? 'flex max-h-[85vh] flex-col' : 'max-w-lg'}>
+                <DialogHeaderEl>
+                  <DialogTitleEl>Tugaskan Staf yang Ada</DialogTitleEl>
+                </DialogHeaderEl>
+                <div
+                  className={cn(
+                    'space-y-4',
+                    isMobile && 'min-h-0 flex-1 overflow-y-auto px-4 pb-[max(1rem,env(safe-area-inset-bottom))]'
+                  )}
+                >
                   {unassignedStaff.length === 0 ? (
                     <p className="text-muted-foreground">Tidak ada staf yang belum ditugaskan</p>
                   ) : (
@@ -236,21 +257,27 @@ export const StoreStaffManagement: React.FC<StoreStaffManagementProps> = ({ stor
                     </div>
                   )}
                 </div>
-              </DialogContent>
-            </Dialog>
+              </DialogContentEl>
+            </DialogRoot>
 
-            <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
-              <DialogTrigger asChild>
-                <Button size="sm" className="w-full sm:w-auto">
-                  <UserPlus className="h-4 w-4 mr-2" />
-                  Tambah Staf Baru
+            <DialogRoot open={createDialogOpen} onOpenChange={setCreateDialogOpen} {...(isMobile ? { shouldScaleBackground: false } : {})}>
+              <DialogTriggerEl asChild>
+                <Button size="sm" className={cn('w-full', isMobile ? 'px-2 text-xs' : 'sm:w-auto')}>
+                  {!isMobile && <UserPlus className="h-4 w-4 mr-2" />}
+                  {isMobile ? 'Tambah Staf' : 'Tambah Staf Baru'}
                 </Button>
-              </DialogTrigger>
-              <DialogContent className="max-w-lg">
-                <DialogHeader>
-                  <DialogTitle>Buat Anggota Staf Baru</DialogTitle>
-                </DialogHeader>
-                <form onSubmit={handleCreateStaff} className="space-y-4">
+              </DialogTriggerEl>
+              <DialogContentEl className={isMobile ? 'flex max-h-[85vh] flex-col' : 'max-w-lg'}>
+                <DialogHeaderEl>
+                  <DialogTitleEl>Buat Anggota Staf Baru</DialogTitleEl>
+                </DialogHeaderEl>
+                <form
+                  onSubmit={handleCreateStaff}
+                  className={cn(
+                    'space-y-4',
+                    isMobile && 'min-h-0 flex-1 overflow-y-auto px-4 pb-[max(1rem,env(safe-area-inset-bottom))]'
+                  )}
+                >
                   <div>
                     <Label htmlFor="email">Email</Label>
                     <Input
@@ -303,8 +330,8 @@ export const StoreStaffManagement: React.FC<StoreStaffManagementProps> = ({ stor
                     </Button>
                   </div>
                 </form>
-              </DialogContent>
-            </Dialog>
+              </DialogContentEl>
+            </DialogRoot>
           </div>
         </div>
       </CardHeader>

--- a/src/hooks/useCustomers.ts
+++ b/src/hooks/useCustomers.ts
@@ -3,7 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useStore } from '@/contexts/StoreContext';
 import { useToast } from '@/hooks/use-toast';
 
-interface Customer {
+export interface Customer {
   id: string;
   name: string;
   phone: string;

--- a/src/pages/CustomersPage.tsx
+++ b/src/pages/CustomersPage.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import {
   Table,
   TableBody,
@@ -22,6 +23,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -62,6 +70,9 @@ import { EditCustomerDialog } from '@/components/pos/EditCustomerDialog';
 import { CustomerPointsCard } from '@/components/customers/CustomerPointsCard';
 import { CustomerPointsBadge } from '@/components/customers/CustomerPointsBadge';
 import { useNavigate } from 'react-router-dom';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
+import { MobilePageHeader } from '@/components/layout/MobilePageHeader';
 
 interface Customer {
   id: string;
@@ -90,7 +101,13 @@ export const CustomersPage: React.FC = () => {
   const { currentStore } = useStore();
   const { toast } = useToast();
   const navigate = useNavigate();
-  
+  const isMobile = useIsMobile();
+  const DetailsRoot = isMobile ? Drawer : Dialog;
+  const DetailsContent = isMobile ? DrawerContent : DialogContent;
+  const DetailsHeader = isMobile ? DrawerHeader : DialogHeader;
+  const DetailsTitle = isMobile ? DrawerTitle : DialogTitle;
+  const DetailsDescription = isMobile ? DrawerDescription : DialogDescription;
+
   const [customers, setCustomers] = useState<Customer[]>([]);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
@@ -354,62 +371,111 @@ export const CustomersPage: React.FC = () => {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div className="flex items-center space-x-4">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => navigate('/home')}
-            className="p-2"
-          >
-            <ArrowLeft className="h-4 w-4" />
-          </Button>
-          <div>
-            <h1 className="text-xl sm:text-2xl font-bold text-foreground">Customers</h1>
-            <p className="text-sm sm:text-base text-muted-foreground">Manage your customer database</p>
-          </div>
-        </div>
-        <AddCustomerDialog
-          trigger={
-            <Button className="w-full sm:w-auto">
-              <Plus className="h-4 w-4 mr-2" />
-              Add Customer
-            </Button>
+      {isMobile ? (
+        <MobilePageHeader
+          title="Customers"
+          onBack={() => navigate('/home')}
+          trailing={
+            <AddCustomerDialog
+              trigger={
+                <Button size="icon" variant="ghost" className="h-9 w-9" aria-label="Add Customer">
+                  <Plus className="h-5 w-5" />
+                </Button>
+              }
+              onCustomerAdded={() => fetchCustomers(pagination.currentPage, debouncedSearchQuery)}
+            />
           }
-          onCustomerAdded={() => fetchCustomers(pagination.currentPage, debouncedSearchQuery)}
         />
-      </div>
+      ) : (
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div className="flex items-center space-x-4">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => navigate('/home')}
+              className="p-2"
+            >
+              <ArrowLeft className="h-4 w-4" />
+            </Button>
+            <div>
+              <h1 className="text-xl sm:text-2xl font-bold text-foreground">Customers</h1>
+              <p className="text-sm sm:text-base text-muted-foreground">Manage your customer database</p>
+            </div>
+          </div>
+          <AddCustomerDialog
+            trigger={
+              <Button className="w-full sm:w-auto">
+                <Plus className="h-4 w-4 mr-2" />
+                Add Customer
+              </Button>
+            }
+            onCustomerAdded={() => fetchCustomers(pagination.currentPage, debouncedSearchQuery)}
+          />
+        </div>
+      )}
 
       {/* Stats Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Total Customers</CardTitle>
-            <Users className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{pagination.totalCount}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Active Customers</CardTitle>
-            <Users className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{activeCustomersCount}</div>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">New This Month</CardTitle>
-            <Calendar className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">{newThisMonthCount}</div>
-          </CardContent>
-        </Card>
-      </div>
+      {isMobile ? (
+        <div className="-mx-4 flex gap-3 overflow-x-auto px-4 pb-1">
+          <Card className="min-w-[130px] flex-shrink-0">
+            <CardContent className="p-3">
+              <div className="mb-1 flex items-center justify-between">
+                <span className="text-xs font-medium text-muted-foreground">Total</span>
+                <Users className="h-3.5 w-3.5 text-muted-foreground" />
+              </div>
+              <div className="text-xl font-bold">{pagination.totalCount}</div>
+            </CardContent>
+          </Card>
+          <Card className="min-w-[130px] flex-shrink-0">
+            <CardContent className="p-3">
+              <div className="mb-1 flex items-center justify-between">
+                <span className="text-xs font-medium text-muted-foreground">Active</span>
+                <Users className="h-3.5 w-3.5 text-muted-foreground" />
+              </div>
+              <div className="text-xl font-bold">{activeCustomersCount}</div>
+            </CardContent>
+          </Card>
+          <Card className="min-w-[130px] flex-shrink-0">
+            <CardContent className="p-3">
+              <div className="mb-1 flex items-center justify-between">
+                <span className="text-xs font-medium text-muted-foreground">New</span>
+                <Calendar className="h-3.5 w-3.5 text-muted-foreground" />
+              </div>
+              <div className="text-xl font-bold">{newThisMonthCount}</div>
+            </CardContent>
+          </Card>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Total Customers</CardTitle>
+              <Users className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{pagination.totalCount}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">Active Customers</CardTitle>
+              <Users className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{activeCustomersCount}</div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+              <CardTitle className="text-sm font-medium">New This Month</CardTitle>
+              <Calendar className="h-4 w-4 text-muted-foreground" />
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-bold">{newThisMonthCount}</div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
 
       {/* Search and Filters */}
       <Card>
@@ -449,106 +515,134 @@ export const CustomersPage: React.FC = () => {
             </div>
           ) : (
             <>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Name</TableHead>
-                    <TableHead className="hidden md:table-cell">Contact</TableHead>
-                    <TableHead className="hidden sm:table-cell">Orders</TableHead>
-                    <TableHead className="hidden lg:table-cell">Joined</TableHead>
-                    <TableHead className="text-right">Actions</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
+              {isMobile ? (
+                <div className="-mx-6 divide-y">
                   {customers.map((customer) => (
-                    <TableRow 
+                    <button
                       key={customer.id}
-                      className="cursor-pointer hover:bg-muted/50"
+                      type="button"
                       onClick={() => handleCustomerClick(customer)}
+                      className="flex w-full items-center gap-3 px-6 py-3 text-left active:bg-muted/50"
                     >
-                      <TableCell>
-                        <div>
-                          <div className="font-medium">{customer.name}</div>
-                          <div className="text-sm text-muted-foreground md:hidden flex items-center gap-1">
-                            <Phone className="h-3 w-3" />
-                            {customer.phone}
-                          </div>
-                          {customer.email && (
-                            <div className="text-sm text-muted-foreground hidden md:block">{customer.email}</div>
-                          )}
+                      <Avatar className="h-10 w-10 flex-shrink-0">
+                        <AvatarFallback className="bg-primary/10 font-semibold text-primary">
+                          {customer.name.charAt(0).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <div className="min-w-0 flex-1">
+                        <div className="truncate font-medium">{customer.name}</div>
+                        <div className="flex items-center gap-1 text-sm text-muted-foreground">
+                          <Phone className="h-3 w-3 flex-shrink-0" />
+                          <span className="truncate">{customer.phone}</span>
                         </div>
-                      </TableCell>
-                      <TableCell className="hidden md:table-cell">
-                        <div className="flex items-center space-x-2">
-                          <Phone className="h-4 w-4 text-muted-foreground" />
-                          <span>{customer.phone}</span>
-                        </div>
-                        {customer.address && (
-                          <div className="flex items-center space-x-2 text-sm text-muted-foreground mt-1">
-                            <MapPin className="h-3 w-3" />
-                            <span className="truncate max-w-[200px]">{customer.address}</span>
-                          </div>
-                        )}
-                      </TableCell>
-                      <TableCell className="hidden sm:table-cell">
-                        <div className="flex flex-col gap-1">
-                          <Badge variant="secondary">
-                            {customer._count?.orders || 0} orders
-                          </Badge>
-                          <CustomerPointsBadge customerPhone={customer.phone} />
-                        </div>
-                      </TableCell>
-                      <TableCell className="text-sm text-muted-foreground hidden lg:table-cell">
-                        {formatDate(customer.created_at)}
-                      </TableCell>
-                      <TableCell className="text-right">
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <Button 
-                              variant="ghost" 
-                              size="sm"
-                              onClick={(e) => e.stopPropagation()}
-                              className="h-8 w-8 p-0"
-                            >
-                              <MoreHorizontal className="h-4 w-4" />
-                            </Button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="end" className="w-48">
-                            <DropdownMenuItem 
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleCustomerClick(customer);
-                              }}
-                            >
-                              <Eye className="h-4 w-4 mr-2" />
-                              View Details
-                            </DropdownMenuItem>
-                            <DropdownMenuItem 
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleEditCustomer(customer);
-                              }}
-                            >
-                              <Edit className="h-4 w-4 mr-2" />
-                              Edit
-                            </DropdownMenuItem>
-                            <DropdownMenuItem 
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                handleDeleteClick(customer);
-                              }}
-                              className="text-destructive"
-                            >
-                              <Trash2 className="h-4 w-4 mr-2" />
-                              Delete
-                            </DropdownMenuItem>
-                          </DropdownMenuContent>
-                        </DropdownMenu>
-                      </TableCell>
-                    </TableRow>
+                      </div>
+                      <CustomerPointsBadge customerPhone={customer.phone} />
+                      <ChevronRight className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                    </button>
                   ))}
-                </TableBody>
-              </Table>
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Name</TableHead>
+                      <TableHead className="hidden md:table-cell">Contact</TableHead>
+                      <TableHead className="hidden sm:table-cell">Orders</TableHead>
+                      <TableHead className="hidden lg:table-cell">Joined</TableHead>
+                      <TableHead className="text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {customers.map((customer) => (
+                      <TableRow
+                        key={customer.id}
+                        className="cursor-pointer hover:bg-muted/50"
+                        onClick={() => handleCustomerClick(customer)}
+                      >
+                        <TableCell>
+                          <div>
+                            <div className="font-medium">{customer.name}</div>
+                            <div className="text-sm text-muted-foreground md:hidden flex items-center gap-1">
+                              <Phone className="h-3 w-3" />
+                              {customer.phone}
+                            </div>
+                            {customer.email && (
+                              <div className="text-sm text-muted-foreground hidden md:block">{customer.email}</div>
+                            )}
+                          </div>
+                        </TableCell>
+                        <TableCell className="hidden md:table-cell">
+                          <div className="flex items-center space-x-2">
+                            <Phone className="h-4 w-4 text-muted-foreground" />
+                            <span>{customer.phone}</span>
+                          </div>
+                          {customer.address && (
+                            <div className="flex items-center space-x-2 text-sm text-muted-foreground mt-1">
+                              <MapPin className="h-3 w-3" />
+                              <span className="truncate max-w-[200px]">{customer.address}</span>
+                            </div>
+                          )}
+                        </TableCell>
+                        <TableCell className="hidden sm:table-cell">
+                          <div className="flex flex-col gap-1">
+                            <Badge variant="secondary">
+                              {customer._count?.orders || 0} orders
+                            </Badge>
+                            <CustomerPointsBadge customerPhone={customer.phone} />
+                          </div>
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground hidden lg:table-cell">
+                          {formatDate(customer.created_at)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={(e) => e.stopPropagation()}
+                                className="h-8 w-8 p-0"
+                              >
+                                <MoreHorizontal className="h-4 w-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end" className="w-48">
+                              <DropdownMenuItem
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleCustomerClick(customer);
+                                }}
+                              >
+                                <Eye className="h-4 w-4 mr-2" />
+                                View Details
+                              </DropdownMenuItem>
+                              <DropdownMenuItem
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleEditCustomer(customer);
+                                }}
+                              >
+                                <Edit className="h-4 w-4 mr-2" />
+                                Edit
+                              </DropdownMenuItem>
+                              <DropdownMenuItem
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  handleDeleteClick(customer);
+                                }}
+                                className="text-destructive"
+                              >
+                                <Trash2 className="h-4 w-4 mr-2" />
+                                Delete
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
 
               {/* Pagination */}
               {pagination.totalPages > 1 && (
@@ -562,17 +656,22 @@ export const CustomersPage: React.FC = () => {
       </Card>
 
       {/* Customer Details Dialog */}
-      <Dialog open={showCustomerDetails} onOpenChange={setShowCustomerDetails}>
-        <DialogContent className="max-w-md">
-          <DialogHeader>
-            <DialogTitle>Customer Details</DialogTitle>
-            <DialogDescription>
+      <DetailsRoot open={showCustomerDetails} onOpenChange={setShowCustomerDetails} {...(isMobile ? { shouldScaleBackground: false } : {})}>
+        <DetailsContent className={isMobile ? 'flex max-h-[85vh] flex-col' : 'max-w-md'}>
+          <DetailsHeader>
+            <DetailsTitle>Customer Details</DetailsTitle>
+            <DetailsDescription>
               View and manage customer information
-            </DialogDescription>
-          </DialogHeader>
-          
+            </DetailsDescription>
+          </DetailsHeader>
+
           {selectedCustomer && (
-            <div className="space-y-4">
+            <div
+              className={cn(
+                'space-y-4',
+                isMobile && 'min-h-0 flex-1 overflow-y-auto px-4 pb-[max(1rem,env(safe-area-inset-bottom))]'
+              )}
+            >
               <div>
                 <h3 className="font-medium text-lg">{selectedCustomer.name}</h3>
                 <p className="text-sm text-muted-foreground">Customer since {formatDate(selectedCustomer.created_at)}</p>
@@ -638,8 +737,8 @@ export const CustomersPage: React.FC = () => {
               </div>
             </div>
           )}
-        </DialogContent>
-      </Dialog>
+        </DetailsContent>
+      </DetailsRoot>
 
       {/* Edit Customer Dialog */}
       <EditCustomerDialog

--- a/src/pages/ServiceManagement.tsx
+++ b/src/pages/ServiceManagement.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Plus, Edit2, Trash2, DollarSign, Settings, AlertCircle } from 'lucide-react';
+import { Plus, Edit2, Trash2, DollarSign, Settings, AlertCircle, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -14,7 +14,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useIsMobile } from '@/hooks/use-mobile';
-import { useServices, useCreateService, useUpdateService, useDeleteService, useSeedDefaultServices, ServiceFormData as ServiceFormType } from '@/hooks/useServices';
+import { useServices, useCreateService, useUpdateService, useDeleteService, useSeedDefaultServices, ServiceFormData as ServiceFormType, ServiceData } from '@/hooks/useServices';
 import { SectionLoading } from '@/components/ui/loading-spinner';
 import { MobilePageHeader } from '@/components/layout/MobilePageHeader';
 import { cn } from '@/lib/utils';
@@ -103,6 +103,17 @@ const ServiceManagement = () => {
     }
   };
 
+  const getPriceLabel = (service: ServiceData) => {
+    const parts: string[] = [];
+    if (service.supports_kilo) {
+      parts.push(`Rp${service.kilo_price?.toLocaleString('id-ID') || '0'}/kg`);
+    }
+    if (service.supports_unit) {
+      parts.push(`Rp${service.unit_price?.toLocaleString('id-ID') || '0'}/unit`);
+    }
+    return parts.join(' · ');
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     
@@ -180,16 +191,18 @@ const ServiceManagement = () => {
     setShowCreateDialog(true);
   };
 
-  const handleDelete = async (serviceId: string) => {
+  const handleDelete = async (serviceId: string): Promise<boolean> => {
     if (!confirm('Apakah Anda yakin ingin menghapus layanan ini?')) {
-      return;
+      return false;
     }
 
     try {
       await deleteServiceMutation.mutateAsync(serviceId);
+      return true;
     } catch (error) {
       // Error handling is done in the mutation hook
       console.error('Error deleting service:', error);
+      return false;
     }
   };
 
@@ -281,6 +294,30 @@ const ServiceManagement = () => {
                 </div>
               </CardContent>
             </Card>
+          ) : isMobile ? (
+            <div className="divide-y rounded-lg border bg-card">
+              {services.map((service) => (
+                <button
+                  key={service.id}
+                  type="button"
+                  onClick={() => handleEdit(service)}
+                  className="flex w-full items-center gap-3 px-4 py-3 text-left active:bg-muted/50"
+                >
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="truncate font-medium">{service.name}</span>
+                      <span className="flex-shrink-0 text-sm font-semibold">{getPriceLabel(service)}</span>
+                    </div>
+                    <div className="truncate text-sm text-muted-foreground">
+                      {getCategoryLabel(service.category)}
+                      {service.duration_value > 0 &&
+                        ` · ${service.duration_value} ${service.duration_unit === 'hours' ? 'jam' : 'hari'}`}
+                    </div>
+                  </div>
+                  <ChevronRight className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+                </button>
+              ))}
+            </div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {services.map((service) => (
@@ -347,18 +384,6 @@ const ServiceManagement = () => {
             </CardContent>
           </Card>
         ))}
-
-        {services.length === 0 && (
-          <div className="col-span-full text-center py-12">
-            <Settings className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
-            <h3 className="text-lg font-semibold mb-2">No services yet</h3>
-            <p className="text-muted-foreground mb-4">Create your first service to get started</p>
-            <Button onClick={openCreateDialog}>
-              <Plus className="h-4 w-4 mr-2" />
-              Add Service
-            </Button>
-          </div>
-        )}
             </div>
           )}
         </>
@@ -524,6 +549,23 @@ const ServiceManagement = () => {
                 </Select>
               </div>
             </div>
+
+            {/* Delete (mobile edit mode only - desktop keeps the per-card delete button) */}
+            {isMobile && editingService && (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full text-destructive hover:text-destructive"
+                onClick={async () => {
+                  if (await handleDelete(editingService.id)) {
+                    setShowCreateDialog(false);
+                  }
+                }}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Hapus Layanan
+              </Button>
+            )}
 
             {/* Form Actions */}
             <div className="flex justify-end space-x-2 pt-4">

--- a/src/pages/ServiceManagement.tsx
+++ b/src/pages/ServiceManagement.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Plus, Edit2, Trash2, DollarSign, Settings, AlertCircle, ChevronRight } from 'lucide-react';
+import { Plus, Edit2, Trash2, DollarSign, Settings, AlertCircle, ChevronRight, Scale, Package } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -103,15 +103,20 @@ const ServiceManagement = () => {
     }
   };
 
-  const getPriceLabel = (service: ServiceData) => {
-    const parts: string[] = [];
+  const PRICE_STYLES = {
+    kilo: { icon: Scale, className: 'text-blue-600' },
+    unit: { icon: Package, className: 'text-purple-600' },
+  } as const;
+
+  const getPriceEntries = (service: ServiceData) => {
+    const entries: { type: keyof typeof PRICE_STYLES; label: string }[] = [];
     if (service.supports_kilo) {
-      parts.push(`Rp${service.kilo_price?.toLocaleString('id-ID') || '0'}/kg`);
+      entries.push({ type: 'kilo', label: `Rp${service.kilo_price?.toLocaleString('id-ID') || '0'}/kg` });
     }
     if (service.supports_unit) {
-      parts.push(`Rp${service.unit_price?.toLocaleString('id-ID') || '0'}/unit`);
+      entries.push({ type: 'unit', label: `Rp${service.unit_price?.toLocaleString('id-ID') || '0'}/unit` });
     }
-    return parts.join(' · ');
+    return entries;
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -306,7 +311,20 @@ const ServiceManagement = () => {
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center justify-between gap-2">
                       <span className="truncate font-medium">{service.name}</span>
-                      <span className="flex-shrink-0 text-sm font-semibold">{getPriceLabel(service)}</span>
+                      <div className="flex flex-shrink-0 flex-wrap items-center justify-end gap-x-2 gap-y-0.5">
+                        {getPriceEntries(service).map(({ type, label }) => {
+                          const { icon: PriceIcon, className } = PRICE_STYLES[type];
+                          return (
+                            <span
+                              key={type}
+                              className={cn('flex items-center gap-1 text-sm font-semibold', className)}
+                            >
+                              <PriceIcon className="h-3.5 w-3.5" />
+                              {label}
+                            </span>
+                          );
+                        })}
+                      </div>
                     </div>
                     <div className="truncate text-sm text-muted-foreground">
                       {getCategoryLabel(service.category)}

--- a/src/pages/ServiceManagement.tsx
+++ b/src/pages/ServiceManagement.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Plus, Edit2, Trash2, DollarSign, Settings, AlertCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -11,8 +13,11 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/hooks/use-toast';
 import { usePageTitle } from '@/hooks/usePageTitle';
+import { useIsMobile } from '@/hooks/use-mobile';
 import { useServices, useCreateService, useUpdateService, useDeleteService, useSeedDefaultServices, ServiceFormData as ServiceFormType } from '@/hooks/useServices';
 import { SectionLoading } from '@/components/ui/loading-spinner';
+import { MobilePageHeader } from '@/components/layout/MobilePageHeader';
+import { cn } from '@/lib/utils';
 
 interface ServiceFormData {
   name: string;
@@ -43,6 +48,12 @@ const initialFormData: ServiceFormData = {
 const ServiceManagement = () => {
   usePageTitle('Manajemen Layanan');
 
+  const navigate = useNavigate();
+  const isMobile = useIsMobile();
+  const FormDialog = isMobile ? Drawer : Dialog;
+  const FormDialogContent = isMobile ? DrawerContent : DialogContent;
+  const FormDialogHeader = isMobile ? DrawerHeader : DialogHeader;
+  const FormDialogTitle = isMobile ? DrawerTitle : DialogTitle;
   const [showCreateDialog, setShowCreateDialog] = useState(false);
   const [editingService, setEditingService] = useState<any>(null);
   const [formData, setFormData] = useState<ServiceFormData>(initialFormData);
@@ -191,20 +202,38 @@ const ServiceManagement = () => {
   return (
     <div className="space-y-6">
       {/* Page Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold">Manajemen Layanan</h1>
-          <p className="text-muted-foreground">Kelola layanan dan harga laundry Anda</p>
+      {isMobile ? (
+        <MobilePageHeader title="Manajemen Layanan" onBack={() => navigate('/home')} />
+      ) : (
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-3xl font-bold">Manajemen Layanan</h1>
+            <p className="text-muted-foreground">Kelola layanan dan harga laundry Anda</p>
+          </div>
+          <Button
+            onClick={openCreateDialog}
+            className="flex items-center space-x-2"
+            disabled={isProcessing}
+          >
+            <Plus className="h-4 w-4" />
+            <span>Tambah Layanan</span>
+          </Button>
         </div>
+      )}
+
+      {/* Mobile FAB */}
+      {isMobile && (
         <Button
           onClick={openCreateDialog}
-          className="flex items-center space-x-2"
           disabled={isProcessing}
+          size="icon"
+          aria-label="Tambah Layanan"
+          className="fixed right-4 z-40 h-14 w-14 rounded-full shadow-medium"
+          style={{ bottom: 'calc(5rem + env(safe-area-inset-bottom))' }}
         >
-          <Plus className="h-4 w-4" />
-          <span>Tambah Layanan</span>
+          <Plus className="h-6 w-6" />
         </Button>
-      </div>
+      )}
 
       {/* Loading State */}
       {loading && <SectionLoading text="Memuat layanan..." />}
@@ -257,9 +286,9 @@ const ServiceManagement = () => {
         {services.map((service) => (
           <Card key={service.id} className="hover:shadow-medium transition-shadow">
             <CardHeader className="pb-3">
-              <div className="flex items-center justify-between">
-                <CardTitle className="text-lg">{service.name}</CardTitle>
-                <Badge className={getCategoryColor(service.category)}>
+              <div className="flex items-center justify-between gap-2">
+                <CardTitle className="min-w-0 truncate text-lg">{service.name}</CardTitle>
+                <Badge className={cn('flex-shrink-0', getCategoryColor(service.category))}>
                   {getCategoryLabel(service.category)}
                 </Badge>
               </div>
@@ -336,15 +365,21 @@ const ServiceManagement = () => {
       )}
 
       {/* Create/Edit Service Dialog */}
-      <Dialog open={showCreateDialog} onOpenChange={setShowCreateDialog}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>
+      <FormDialog open={showCreateDialog} onOpenChange={setShowCreateDialog} {...(isMobile ? { shouldScaleBackground: false } : {})}>
+        <FormDialogContent className={isMobile ? 'max-h-[85vh] flex flex-col' : 'max-w-2xl'}>
+          <FormDialogHeader>
+            <FormDialogTitle>
               {editingService ? 'Edit Layanan' : 'Buat Layanan Baru'}
-            </DialogTitle>
-          </DialogHeader>
+            </FormDialogTitle>
+          </FormDialogHeader>
 
-          <form onSubmit={handleSubmit} className="space-y-6">
+          <form
+            onSubmit={handleSubmit}
+            className={cn(
+              'space-y-6',
+              isMobile && 'min-h-0 flex-1 overflow-y-auto px-4 pb-[max(1rem,env(safe-area-inset-bottom))]'
+            )}
+          >
             {/* Basic Information */}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
@@ -505,8 +540,8 @@ const ServiceManagement = () => {
               </Button>
             </div>
           </form>
-        </DialogContent>
-      </Dialog>
+        </FormDialogContent>
+      </FormDialog>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Adds a shared `MobilePageHeader` (back arrow + truncated title + trailing action) used by Service and Customer management, replacing oversized non-responsive `text-3xl` titles on mobile.
- Service management: mobile gets a FAB for "add service" (positioned clear of the bottom nav) and the create/edit form opens as a bottom-sheet drawer instead of a centered dialog.
- Customer management: mobile gets a horizontally-scrollable stat strip (instead of 3 full-width stacked cards), the customer table becomes a tappable avatar/name/phone card list, and Add/Edit/Details all use bottom-sheet drawers.
- `AddCustomerDialog`/`EditCustomerDialog` are internally responsive (drawer on mobile, dialog on desktop), so all 4 existing call sites (header, sidebar, dashboard quick actions, customers page) get consistent behavior with no per-call-site changes.
- Staff management (Store Management "Staf" tab): mobile title no longer repeats the store name (already shown by the tab's parent header), and the two staff actions render as a compact button row; both dialogs use drawers.
- All changes are mobile-only (`useIsMobile()`, 768px breakpoint, matching the codebase's existing branching convention) — desktop layouts are pixel-identical to before.

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run build` — succeeds
- [x] `npx eslint` on all changed files — 0 new errors/warnings (pre-existing `no-explicit-any` / `exhaustive-deps` issues unchanged)
- [x] Manual verification via headless Playwright against a real logged-in session at 375px and 1280px for all three surfaces (Service, Customer, Staff tab): headers, FAB placement above the bottom nav, drawer open/scroll/close, table↔card-list swap, and confirmed desktop is visually unchanged, with zero console errors
- [ ] Manual spot-check on a physical Android device recommended before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable mobile page header with back navigation and optional actions.
  * Added responsive mobile layouts for customer, service, and staff management screens.
  * Customer listings now display as tappable avatar rows on mobile, with horizontally scrollable summary statistics.
  * Service management includes a mobile-friendly header, form drawer, and floating action button.

* **Enhancements**
  * Customer, staff, and service forms now use drawers on mobile and dialogs on larger screens.
  * Improved mobile scrolling, spacing, sizing, and safe-area support.
  * Improved handling of long service names and category labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->