### PR TITLE
feat(pos): opt-in offline order creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,8 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
         "date-fns": "^3.6.0",
+        "dexie": "^4.4.4",
+        "dexie-react-hooks": "^4.4.0",
         "dotenv": "^17.2.1",
         "embla-carousel-react": "^8.3.0",
         "html2canvas": "^1.4.1",
@@ -5093,6 +5095,22 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dexie": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.4.4.tgz",
+      "integrity": "sha512-jIwsYI8Os2hgnqc6O49YwFDKGc5v5QjGx0wPVp543ip1F53VFAKMLthV2pQosQcVTv3eAskTWYspOx195PM0FQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/dexie-react-hooks": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/dexie-react-hooks/-/dexie-react-hooks-4.4.0.tgz",
+      "integrity": "sha512-ObLXBS5+4BJU8vtSvBx6b9fY6zZYgniAtwxzjCHsUQadgbqYN6935X2/1TWw4Rf2N1aZV1io5/ziox4vKuxABA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "dexie": ">=4.2.0-alpha.1 <5.0.0",
+        "react": ">=16"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,8 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
     "date-fns": "^3.6.0",
+    "dexie": "^4.4.4",
+    "dexie-react-hooks": "^4.4.0",
     "dotenv": "^17.2.1",
     "embla-carousel-react": "^8.3.0",
     "html2canvas": "^1.4.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,16 +23,26 @@ import { AppLayout } from "./components/layout/AppLayout";
 import { AndroidBackButtonHandler } from "./components/layout/AndroidBackButtonHandler";
 import { NativeSplashScreenHider } from "./components/layout/NativeSplashScreenHider";
 import { queryClient } from "./lib/queryClient";
+import { useOfflineOrderSync } from "./hooks/useOfflineOrderSync";
 import { PublicReceiptPage } from "./pages/PublicReceiptPage";
 import { PWAManagementPage } from "./pages/PWAManagementPage";
 import { CustomersPage } from "./pages/CustomersPage";
 import { WhatsAppBroadcastPage } from "./pages/WhatsAppBroadcastPage";
 import { RevenueReportPage } from "./pages/RevenueReportPage";
 
+// Mounted once for the app's lifetime: wires the unified offline-sync
+// trigger set (online event, focus/visibility, foreground poll) so queued
+// orders sync automatically without any per-page setup.
+const OfflineSyncEngine = () => {
+  useOfflineOrderSync();
+  return null;
+};
+
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <TooltipProvider>
       <NativeSplashScreenHider />
+      <OfflineSyncEngine />
       <Toaster />
       <Sonner
         position="top-center"

--- a/src/components/pos/EnhancedLaundryPOS.tsx
+++ b/src/components/pos/EnhancedLaundryPOS.tsx
@@ -63,18 +63,13 @@ export const EnhancedLaundryPOS = () => {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const serviceSectionRef = useRef<HTMLDivElement>(null);
 
-  // Routes an order through the normal online mutation, or - only when this
-  // store has opted in - queues it locally to sync automatically once
-  // connectivity returns. Points redemption is never part of the offline
-  // path (see docs on offline order creation): the field is stripped here,
-  // not just zeroed, so an offline order can never carry a stale redemption
-  // the sync worker would otherwise have to reconcile against a balance it
-  // has no live read on.
-  const submitOrder = async (orderData: CreateOrderData): Promise<{ id: string; points_earned?: number }> => {
-    if (isOnline) {
-      return await createOrderMutation.mutateAsync(orderData);
-    }
-
+  // Queues an order locally to sync automatically once connectivity
+  // returns. Points redemption is never part of the offline path (see docs
+  // on offline order creation): the field is stripped here, not just
+  // zeroed, so an offline order can never carry a stale redemption the
+  // sync worker would otherwise have to reconcile against a balance it has
+  // no live read on.
+  const queueOrderOffline = async (orderData: CreateOrderData): Promise<{ id: string; points_earned?: number }> => {
     if (!currentStore?.enable_offline_mode) {
       toast.error('❌ Toko belum mengaktifkan mode offline. Sambungkan internet untuk membuat pesanan.', {
         style: ORDER_ERROR_TOAST_STYLE,
@@ -104,11 +99,38 @@ export const EnhancedLaundryPOS = () => {
     } catch (error) {
       if (error instanceof OfflineSessionExpiredError) {
         toast.error(`❌ ${error.message}`, { style: ORDER_ERROR_TOAST_STYLE });
+      } else {
+        // Any other failure (e.g. an IndexedDB write/quota error) means the
+        // order was neither queued nor created - staff must be told, not
+        // just left with a dialog that quietly closes.
+        toast.error('❌ Gagal menyimpan pesanan offline. Silakan coba lagi.', {
+          style: ORDER_ERROR_TOAST_STYLE,
+        });
       }
       throw error;
     } finally {
       setIsQueuingOffline(false);
     }
+  };
+
+  // Routes an order through the normal online mutation, or - only when this
+  // store has opted in - queues it locally instead. `navigator.onLine` can
+  // report true while the device has no real route to the internet, so a
+  // failed online attempt still falls back to the offline queue rather
+  // than surfacing a lost order.
+  const submitOrder = async (orderData: CreateOrderData): Promise<{ id: string; points_earned?: number }> => {
+    if (isOnline) {
+      try {
+        return await createOrderMutation.mutateAsync(orderData);
+      } catch (error) {
+        if (!currentStore?.enable_offline_mode) {
+          throw error;
+        }
+        return queueOrderOffline(orderData);
+      }
+    }
+
+    return queueOrderOffline(orderData);
   };
 
   // Load services from our service management system

--- a/src/components/pos/EnhancedLaundryPOS.tsx
+++ b/src/components/pos/EnhancedLaundryPOS.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { Search, Plus, Clock, CreditCard, User, ShoppingCart, CheckCircle, X, CheckCircle2, ArrowDown, ChevronDown } from 'lucide-react';
+import { Search, Plus, Clock, CreditCard, User, ShoppingCart, CheckCircle, X, CheckCircle2, ArrowDown, ChevronDown, WifiOff } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -7,9 +7,13 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { useNavigate } from 'react-router-dom';
 import { useCustomers } from '@/hooks/useCustomers';
-import { useCreateOrderWithNotifications as useCreateOrder, UnitItem } from '@/hooks/useOrdersWithNotifications';
+import { useCreateOrderWithNotifications as useCreateOrder, UnitItem, CreateOrderData } from '@/hooks/useOrdersWithNotifications';
 import { toast } from 'sonner';
 import { useServices, useSeedDefaultServices } from '@/hooks/useServices';
+import { useStore } from '@/contexts/StoreContext';
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
+import { queueOfflineOrder, OfflineSessionExpiredError, usePendingOrders } from '@/hooks/useOfflineOrderQueue';
+import { buildReceiptDataFromLocalOrder, type LocalReceiptData } from '@/lib/printUtils';
 import { EnhancedOrderItem, DynamicOrderItemData } from './orderTypes';
 import { getJakartaNow, buildOrderItems, validateOrderReadiness, ORDER_ERROR_TOAST_STYLE } from './orderPayload';
 import { InlineServiceSelector, Service as CatalogService, DynamicItem } from './InlineServiceSelector';
@@ -47,12 +51,65 @@ export const EnhancedLaundryPOS = () => {
   // Collapsed until customer info is complete, then auto-expands - no point
   // showing the service list before there's a customer to attach it to.
   const [isServiceSectionExpanded, setIsServiceSectionExpanded] = useState(false);
+  const [isQueuingOffline, setIsQueuingOffline] = useState(false);
+  const [offlineReceiptData, setOfflineReceiptData] = useState<LocalReceiptData | null>(null);
 
   const navigate = useNavigate();
   const { customers, searchCustomers, getCustomerByPhone, loading: customersLoading } = useCustomers();
   const createOrderMutation = useCreateOrder();
+  const { currentStore } = useStore();
+  const isOnline = useOnlineStatus();
+  const pendingOfflineOrders = usePendingOrders(currentStore?.store_id);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const serviceSectionRef = useRef<HTMLDivElement>(null);
+
+  // Routes an order through the normal online mutation, or - only when this
+  // store has opted in - queues it locally to sync automatically once
+  // connectivity returns. Points redemption is never part of the offline
+  // path (see docs on offline order creation): the field is stripped here,
+  // not just zeroed, so an offline order can never carry a stale redemption
+  // the sync worker would otherwise have to reconcile against a balance it
+  // has no live read on.
+  const submitOrder = async (orderData: CreateOrderData): Promise<{ id: string; points_earned?: number }> => {
+    if (isOnline) {
+      return await createOrderMutation.mutateAsync(orderData);
+    }
+
+    if (!currentStore?.enable_offline_mode) {
+      toast.error('❌ Toko belum mengaktifkan mode offline. Sambungkan internet untuk membuat pesanan.', {
+        style: ORDER_ERROR_TOAST_STYLE,
+      });
+      throw new Error('OFFLINE_MODE_DISABLED');
+    }
+
+    setIsQueuingOffline(true);
+    try {
+      const { points_redeemed, ...offlinePayload } = orderData;
+      const localId = await queueOfflineOrder(currentStore.store_id, offlinePayload);
+
+      setOfflineReceiptData(
+        buildReceiptDataFromLocalOrder(localId, offlinePayload, {
+          name: currentStore.store_name,
+          address: currentStore.store_address,
+          phone: currentStore.store_phone,
+          enable_qr: currentStore.enable_qr,
+        })
+      );
+
+      toast.success('Pesanan disimpan offline - akan sinkron otomatis saat koneksi kembali', {
+        duration: 4000,
+      });
+
+      return { id: localId, points_earned: 0 };
+    } catch (error) {
+      if (error instanceof OfflineSessionExpiredError) {
+        toast.error(`❌ ${error.message}`, { style: ORDER_ERROR_TOAST_STYLE });
+      }
+      throw error;
+    } finally {
+      setIsQueuingOffline(false);
+    }
+  };
 
   // Load services from our service management system
   const { data: servicesData, isLoading: servicesLoading, error: servicesError } = useServices();
@@ -387,7 +444,7 @@ export const EnhancedLaundryPOS = () => {
         estimated_completion: completionDate?.toISOString(),
       };
 
-      const createdOrder = await createOrderMutation.mutateAsync(orderData);
+      const createdOrder = await submitOrder(orderData);
 
       // Close cash payment dialog
       setShowCashPaymentDialog(false);
@@ -430,7 +487,7 @@ export const EnhancedLaundryPOS = () => {
         estimated_completion: completionDate?.toISOString(),
       };
 
-      const createdOrder = await createOrderMutation.mutateAsync(orderData);
+      const createdOrder = await submitOrder(orderData);
 
       // Show order success dialog
       showOrderSuccess(createdOrder, totalAmount, paymentMethod);
@@ -474,7 +531,7 @@ export const EnhancedLaundryPOS = () => {
         estimated_completion: completionDate?.toISOString(),
       };
 
-      const createdOrder = await createOrderMutation.mutateAsync(orderData);
+      const createdOrder = await submitOrder(orderData);
 
       // Show order success dialog for draft order (same as paid orders)
       showOrderSuccess(createdOrder, totalAmount, 'pending');
@@ -544,6 +601,7 @@ export const EnhancedLaundryPOS = () => {
     
     // Reset last created order
     setLastCreatedOrder(null);
+    setOfflineReceiptData(null);
 
     // Reset drop off date to current time
     setDropOffDate(getJakartaNow());
@@ -556,6 +614,7 @@ export const EnhancedLaundryPOS = () => {
     setCustomerName('');
     setCustomerPhone('');
     setLastCreatedOrder(null);
+    setOfflineReceiptData(null);
   };
 
   if (servicesLoading) {
@@ -585,8 +644,39 @@ export const EnhancedLaundryPOS = () => {
     );
   }
 
+  const pendingSyncCount = pendingOfflineOrders.filter(
+    (o) => o.status === 'queued' || o.status === 'syncing' || o.status === 'error_retryable'
+  ).length;
+  const failedSyncCount = pendingOfflineOrders.filter((o) => o.status === 'error_permanent').length;
+
   return (
     <div className="space-y-4 sm:space-y-6">
+      {/* Offline / Sync Status Banner */}
+      {(!isOnline || pendingSyncCount > 0 || failedSyncCount > 0) && (
+        <Card className={failedSyncCount > 0 ? 'border-destructive/40 bg-destructive/5' : 'border-pos-warning/40 bg-pos-warning/10'}>
+          <CardContent className="p-3 sm:p-4">
+            <div className="flex items-start gap-2 text-sm">
+              <WifiOff className={`mt-0.5 h-4 w-4 flex-shrink-0 ${failedSyncCount > 0 ? 'text-destructive' : 'text-pos-warning'}`} />
+              <div className="space-y-1">
+                {!isOnline && (
+                  <p className={failedSyncCount > 0 ? 'text-destructive' : 'text-pos-warning'}>
+                    {currentStore?.enable_offline_mode
+                      ? 'Anda sedang offline - pesanan baru disimpan di perangkat dan akan tersinkron otomatis saat koneksi kembali.'
+                      : 'Anda sedang offline - toko ini belum mengaktifkan mode offline, jadi pesanan baru belum bisa dibuat sampai koneksi kembali.'}
+                  </p>
+                )}
+                {pendingSyncCount > 0 && (
+                  <p className="text-muted-foreground">{pendingSyncCount} pesanan menunggu sinkronisasi</p>
+                )}
+                {failedSyncCount > 0 && (
+                  <p className="font-medium text-destructive">{failedSyncCount} pesanan gagal sinkron - perlu ditinjau di Riwayat Pesanan</p>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
       {/* Service Management Notice */}
       {servicesData && servicesData.length === 0 && (
         <Card className="border-pos-warning/40 bg-pos-warning/10">
@@ -799,7 +889,7 @@ export const EnhancedLaundryPOS = () => {
         onProcessPayment={processPayment}
         onCreateDraft={createDraftOrder}
         onOpenServicePopup={() => serviceSectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })}
-        isProcessing={createOrderMutation.isPending}
+        isProcessing={createOrderMutation.isPending || isQueuingOffline}
         customerName={customerName}
         customerPhone={customerPhone}
         calculateFinishDate={calculateFinishDate}
@@ -845,8 +935,9 @@ export const EnhancedLaundryPOS = () => {
         <ThermalPrintDialog
           isOpen={showThermalPrintDialog}
           onClose={() => setShowThermalPrintDialog(false)}
-          orderId={lastCreatedOrder.id}
+          orderId={offlineReceiptData ? null : lastCreatedOrder.id}
           customerName={lastCreatedOrder.customerName}
+          localReceiptData={offlineReceiptData}
         />
       )}
     </div>

--- a/src/components/pos/FloatingOrderSummary.tsx
+++ b/src/components/pos/FloatingOrderSummary.tsx
@@ -9,6 +9,7 @@ import { Label } from '@/components/ui/label';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useCustomerPoints } from '@/hooks/useCustomerPoints';
 import { useStore } from '@/contexts/StoreContext';
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { DynamicOrderItemData } from './orderTypes';
 
 interface OrderItem {
@@ -87,6 +88,7 @@ export const FloatingOrderSummary: React.FC<FloatingOrderSummaryProps> = ({
   const [justAdded, setJustAdded] = useState(false);
 
   const { currentStore } = useStore();
+  const isOnline = useOnlineStatus();
   const { data: customerPoints } = useCustomerPoints(customerPhone);
 
   const itemCount = currentOrder.reduce((sum, item) => sum + item.quantity, 0) + dynamicItems.length;
@@ -138,6 +140,21 @@ export const FloatingOrderSummary: React.FC<FloatingOrderSummaryProps> = ({
       onPointsRedeemedChange(points);
     }
   };
+
+  // Points redemption can't be validated against a live balance offline
+  // (see docs on offline order creation) - if connectivity drops while the
+  // points tab is active, fall back to no discount rather than let a
+  // redemption amount linger that offline order submission will silently
+  // strip anyway.
+  useEffect(() => {
+    if (!isOnline && discountType === 'points') {
+      setDiscountType('custom');
+      setPointsToRedeem('');
+      setCustomDiscount('');
+      onDiscountChange(0);
+      onPointsRedeemedChange(0);
+    }
+  }, [isOnline, discountType, onDiscountChange, onPointsRedeemedChange]);
 
   // Reset payment started state when processing completes or fails
   useEffect(() => {
@@ -394,11 +411,14 @@ export const FloatingOrderSummary: React.FC<FloatingOrderSummaryProps> = ({
                     <Percent className="h-3 w-3" />
                     Kustom
                   </TabsTrigger>
-                  <TabsTrigger value="points" className="flex items-center gap-1 text-xs" disabled={!hasPoints}>
+                  <TabsTrigger value="points" className="flex items-center gap-1 text-xs" disabled={!hasPoints || !isOnline}>
                     <Gift className="h-3 w-3" />
                     Poin {hasPoints && `(${pointsAvailable})`}
                   </TabsTrigger>
                 </TabsList>
+                {!isOnline && (
+                  <p className="mt-1 text-xs text-muted-foreground">Penukaran poin tidak tersedia saat offline</p>
+                )}
                 <TabsContent value="custom" className="space-y-1 mt-2">
                   <Input
                     type="number"

--- a/src/components/stores/StoreSettingsCard.tsx
+++ b/src/components/stores/StoreSettingsCard.tsx
@@ -7,12 +7,13 @@ import { toast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 import { useStore } from '@/contexts/StoreContext';
 import { authService } from '@/services/authService';
-import { QrCode, Settings, Save, Star } from 'lucide-react';
+import { QrCode, Settings, Save, Star, WifiOff } from 'lucide-react';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 
 interface StoreSettings {
   enable_qr: boolean;
   enable_points: boolean;
+  enable_offline_mode: boolean;
 }
 
 export const StoreSettingsCard: React.FC = () => {
@@ -20,6 +21,7 @@ export const StoreSettingsCard: React.FC = () => {
   const [settings, setSettings] = useState<StoreSettings>({
     enable_qr: false,
     enable_points: false,
+    enable_offline_mode: false,
   });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -37,7 +39,7 @@ export const StoreSettingsCard: React.FC = () => {
       setLoading(true);
       const { data, error } = await supabase
         .from('stores')
-        .select('enable_qr, enable_points')
+        .select('enable_qr, enable_points, enable_offline_mode')
         .eq('id', currentStore.store_id)
         .single();
 
@@ -55,6 +57,7 @@ export const StoreSettingsCard: React.FC = () => {
         setSettings({
           enable_qr: data.enable_qr || false,
           enable_points: data.enable_points || false,
+          enable_offline_mode: data.enable_offline_mode || false,
         });
       }
     } catch (error) {
@@ -81,6 +84,7 @@ export const StoreSettingsCard: React.FC = () => {
       await authService.setStoreFeatureFlags(currentStore.store_id, {
         enableQr: settings.enable_qr,
         enablePoints: settings.enable_points,
+        enableOfflineMode: settings.enable_offline_mode,
       });
 
       toast({
@@ -110,6 +114,13 @@ export const StoreSettingsCard: React.FC = () => {
     setSettings(prev => ({
       ...prev,
       enable_points: checked,
+    }));
+  };
+
+  const handleOfflineModeToggle = (checked: boolean) => {
+    setSettings(prev => ({
+      ...prev,
+      enable_offline_mode: checked,
     }));
   };
 
@@ -233,6 +244,53 @@ export const StoreSettingsCard: React.FC = () => {
                         <li>• Pelanggan mendapat 1 poin per unit untuk layanan berbasis jumlah</li>
                         <li>• Poin secara otomatis diberikan saat pembayaran selesai</li>
                         <li>• Saldo poin terlihat pada struk dan profil pelanggan</li>
+                      </ul>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Offline Mode Settings */}
+            <div className="space-y-4">
+              <div className="flex items-center space-x-2">
+                <WifiOff className="h-5 w-5 text-muted-foreground" />
+                <Label htmlFor="enable-offline-mode" className="text-base font-medium">
+                  Mode Offline
+                </Label>
+              </div>
+
+              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 p-4 border rounded-lg">
+                <div className="space-y-1 flex-1">
+                  <Label htmlFor="enable-offline-mode" className="font-normal">
+                    Izinkan Buat Pesanan Saat Offline
+                  </Label>
+                  <p className="text-sm text-muted-foreground">
+                    Staf tetap bisa membuat pesanan baru saat internet toko putus - pesanan tersimpan di perangkat dan otomatis sinkron saat koneksi kembali
+                  </p>
+                </div>
+                <Switch
+                  id="enable-offline-mode"
+                  checked={settings.enable_offline_mode}
+                  onCheckedChange={handleOfflineModeToggle}
+                  disabled={saving}
+                  className="self-start sm:self-center"
+                />
+              </div>
+
+              {settings.enable_offline_mode && (
+                <div className="p-4 bg-slate-50 border border-slate-200 rounded-lg">
+                  <div className="flex items-start gap-3">
+                    <WifiOff className="h-5 w-5 text-slate-600 mt-0.5" />
+                    <div className="space-y-1">
+                      <p className="text-sm font-medium text-slate-900">
+                        Mode Offline Aktif
+                      </p>
+                      <ul className="text-sm text-slate-700 space-y-1">
+                        <li>• Hanya berlaku untuk pembuatan pesanan baru - status/pembayaran pesanan tetap butuh koneksi internet</li>
+                        <li>• Penukaran poin tidak tersedia untuk pesanan yang dibuat offline</li>
+                        <li>• Staf harus login ulang jika sesi mereka habis saat offline sebelum bisa membuat pesanan baru</li>
+                        <li>• Harga layanan yang dipakai offline mengikuti data terakhir saat perangkat masih online</li>
                       </ul>
                     </div>
                   </div>

--- a/src/components/thermal/ThermalPrintDialog.tsx
+++ b/src/components/thermal/ThermalPrintDialog.tsx
@@ -37,16 +37,22 @@ export const ThermalPrintDialog: React.FC<ThermalPrintDialogProps> = ({
     console.error('Thermal print error:', error);
   };
 
+  // For an offline order, orderId is null (it hasn't synced to Supabase
+  // yet) but localReceiptData carries its local id - fall back to that so
+  // the description still shows the specific receipt being printed
+  // instead of the generic "connect your printer" message.
+  const displayOrderId = orderId || localReceiptData?.orderId;
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
           <DialogTitle>Thermal Printer</DialogTitle>
           <DialogDescription>
-            {customerName && orderId ? (
-              <>Print receipt for <strong>{customerName}</strong> (Order #{orderId})</>
-            ) : orderId ? (
-              <>Print receipt for Order #{orderId}</>
+            {customerName && displayOrderId ? (
+              <>Print receipt for <strong>{customerName}</strong> (Order #{displayOrderId})</>
+            ) : displayOrderId ? (
+              <>Print receipt for Order #{displayOrderId}</>
             ) : (
               'Connect to your thermal printer to print receipts'
             )}

--- a/src/components/thermal/ThermalPrintDialog.tsx
+++ b/src/components/thermal/ThermalPrintDialog.tsx
@@ -7,19 +7,25 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { ThermalPrinterManager } from '@/components/thermal/ThermalPrinterManager';
+import type { LocalReceiptData } from '@/lib/printUtils';
 
 interface ThermalPrintDialogProps {
   isOpen: boolean;
   onClose: () => void;
   orderId: string | null;
   customerName?: string;
+  // In-memory receipt for an offline order that hasn't synced to Supabase
+  // yet - bypasses the get_receipt_data RPC, which requires a
+  // server-confirmed order.
+  localReceiptData?: LocalReceiptData;
 }
 
 export const ThermalPrintDialog: React.FC<ThermalPrintDialogProps> = ({
   isOpen,
   onClose,
   orderId,
-  customerName
+  customerName,
+  localReceiptData
 }) => {
   const handlePrintSuccess = () => {
     // Keep dialog open so user can print more receipts if needed
@@ -49,6 +55,7 @@ export const ThermalPrintDialog: React.FC<ThermalPrintDialogProps> = ({
         
         <ThermalPrinterManager
           orderId={orderId || undefined}
+          localReceiptData={localReceiptData}
           onPrintSuccess={handlePrintSuccess}
           onPrintError={handlePrintError}
         />

--- a/src/components/thermal/ThermalPrinterManager.tsx
+++ b/src/components/thermal/ThermalPrinterManager.tsx
@@ -15,26 +15,33 @@ import {
   Settings
 } from 'lucide-react';
 import { toast } from 'sonner';
-import { 
+import {
   isBluetoothSupported,
   isThermerAppAvailable,
   printToThermalPrinter,
   printToThermerApp,
-  fetchReceiptDataForThermal
+  fetchReceiptDataForThermal,
+  type LocalReceiptData
 } from '@/lib/printUtils';
 import { useThermalPrinter } from '@/contexts/ThermalPrinterContext';
 
 interface ThermalPrinterManagerProps {
   orderId?: string;
+  // When set, printing uses this in-memory receipt directly instead of
+  // fetching via the get_receipt_data RPC - for orders not yet synced to
+  // Supabase (offline order creation).
+  localReceiptData?: LocalReceiptData;
   onPrintSuccess?: () => void;
   onPrintError?: (error: string) => void;
 }
 
 export const ThermalPrinterManager: React.FC<ThermalPrinterManagerProps> = ({
   orderId,
+  localReceiptData,
   onPrintSuccess,
   onPrintError
 }) => {
+  const canPrint = Boolean(orderId || localReceiptData);
   const [isPrinting, setIsPrinting] = useState(false);
   
   // Use thermal printer context for global connection management
@@ -58,7 +65,7 @@ export const ThermalPrinterManager: React.FC<ThermalPrinterManagerProps> = ({
   }, [disconnectPrinter]);
 
   const handlePrintBluetooth = useCallback(async () => {
-    if (!printerConnection || !orderId) {
+    if (!printerConnection || !canPrint) {
       return;
     }
 
@@ -66,9 +73,10 @@ export const ThermalPrinterManager: React.FC<ThermalPrinterManagerProps> = ({
     clearError();
 
     try {
-      // Fetch receipt data
-      const receiptData = await fetchReceiptDataForThermal(orderId);
-      
+      // Fetch receipt data, unless we already have it in memory (an
+      // offline order that hasn't synced to Supabase yet).
+      const receiptData = localReceiptData ?? await fetchReceiptDataForThermal(orderId!);
+
       // Print to thermal printer
       await printToThermalPrinter(receiptData, printerConnection, {
         paperWidth: 32,
@@ -90,18 +98,19 @@ export const ThermalPrinterManager: React.FC<ThermalPrinterManagerProps> = ({
     } finally {
       setIsPrinting(false);
     }
-  }, [printerConnection, orderId, onPrintSuccess, onPrintError, clearError]);
+  }, [printerConnection, canPrint, orderId, localReceiptData, onPrintSuccess, onPrintError, clearError]);
 
   const handlePrintThermer = useCallback(async () => {
-    if (!orderId) return;
+    if (!canPrint) return;
 
     setIsPrinting(true);
     clearError();
 
     try {
-      // Fetch receipt data
-      const receiptData = await fetchReceiptDataForThermal(orderId);
-      
+      // Fetch receipt data, unless we already have it in memory (an
+      // offline order that hasn't synced to Supabase yet).
+      const receiptData = localReceiptData ?? await fetchReceiptDataForThermal(orderId!);
+
       // Print via Thermer app
       await printToThermerApp(receiptData);
 
@@ -119,7 +128,7 @@ export const ThermalPrinterManager: React.FC<ThermalPrinterManagerProps> = ({
     } finally {
       setIsPrinting(false);
     }
-  }, [orderId, onPrintSuccess, onPrintError, clearError]);
+  }, [canPrint, orderId, localReceiptData, onPrintSuccess, onPrintError, clearError]);
 
   const bluetoothSupported = isBluetoothSupported();
   const thermerAvailable = isThermerAppAvailable();
@@ -183,7 +192,7 @@ export const ThermalPrinterManager: React.FC<ThermalPrinterManagerProps> = ({
                 <>
                   <Button
                     onClick={handlePrintBluetooth}
-                    disabled={isPrinting || !orderId}
+                    disabled={isPrinting || !canPrint}
                     className="flex items-center space-x-2"
                     size="sm"
                   >
@@ -245,7 +254,7 @@ export const ThermalPrinterManager: React.FC<ThermalPrinterManagerProps> = ({
 
             <Button
               onClick={handlePrintThermer}
-              disabled={isPrinting || !orderId}
+              disabled={isPrinting || !canPrint}
               variant="outline"
               size="sm"
               className="flex items-center space-x-2 w-full"

--- a/src/hooks/useCustomers.ts
+++ b/src/hooks/useCustomers.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useStore } from '@/contexts/StoreContext';
 import { useToast } from '@/hooks/use-toast';
+import { offlineDb } from '@/lib/offlineDb';
 
 export interface Customer {
   id: string;
@@ -14,11 +15,38 @@ export interface Customer {
   updated_at: string;
 }
 
+const filterCachedCustomers = (customers: Customer[], query: string): Customer[] => {
+  const q = query.toLowerCase();
+  return customers.filter(
+    (c) => c.name.toLowerCase().includes(q) || c.phone.toLowerCase().includes(q)
+  );
+};
+
 export const useCustomers = () => {
   const [customers, setCustomers] = useState<Customer[]>([]);
   const [loading, setLoading] = useState(false);
   const { currentStore } = useStore();
   const { toast } = useToast();
+
+  // Background write-through: whenever a store is selected and we're
+  // online, refresh the full customer-list cache for that store so
+  // searchCustomers has something to fall back on once offline.
+  useEffect(() => {
+    const storeId = currentStore?.store_id;
+    if (!storeId || !navigator.onLine) return;
+
+    (async () => {
+      const { data, error } = await supabase
+        .from('customers')
+        .select('*')
+        .eq('store_id', storeId)
+        .order('created_at', { ascending: false });
+
+      if (!error && data) {
+        await offlineDb.cachedCustomers.put({ storeId, customers: data, cachedAt: Date.now() });
+      }
+    })();
+  }, [currentStore?.store_id]);
 
   const searchCustomers = async (query: string) => {
     if (!currentStore) {
@@ -32,6 +60,12 @@ export const useCustomers = () => {
 
     setLoading(true);
     try {
+      if (!navigator.onLine) {
+        const cached = await offlineDb.cachedCustomers.get(currentStore.store_id);
+        setCustomers(filterCachedCustomers(cached?.customers ?? [], query));
+        return;
+      }
+
       const { data, error } = await supabase
         .from('customers')
         .select('*')
@@ -43,6 +77,12 @@ export const useCustomers = () => {
       setCustomers(data || []);
     } catch (error) {
       console.error('Error searching customers:', error);
+      try {
+        const cached = await offlineDb.cachedCustomers.get(currentStore.store_id);
+        setCustomers(filterCachedCustomers(cached?.customers ?? [], query));
+      } catch {
+        // no cache available either - fall through to the error toast below
+      }
       toast({
         title: "Error",
         description: "Failed to search customers",

--- a/src/hooks/useCustomers.ts
+++ b/src/hooks/useCustomers.ts
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useStore } from '@/contexts/StoreContext';
 import { useToast } from '@/hooks/use-toast';
+import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { offlineDb } from '@/lib/offlineDb';
 
 export interface Customer {
@@ -27,13 +28,18 @@ export const useCustomers = () => {
   const [loading, setLoading] = useState(false);
   const { currentStore } = useStore();
   const { toast } = useToast();
+  const isOnline = useOnlineStatus();
 
   // Background write-through: whenever a store is selected and we're
   // online, refresh the full customer-list cache for that store so
-  // searchCustomers has something to fall back on once offline.
+  // searchCustomers has something to fall back on once offline. Also
+  // re-runs when connectivity itself returns (not just on store change) -
+  // otherwise a store that loaded while already offline, or a session
+  // that regains connectivity without switching stores, would never get a
+  // fresh cache.
   useEffect(() => {
     const storeId = currentStore?.store_id;
-    if (!storeId || !navigator.onLine) return;
+    if (!storeId || !isOnline) return;
 
     (async () => {
       const { data, error } = await supabase
@@ -46,7 +52,7 @@ export const useCustomers = () => {
         await offlineDb.cachedCustomers.put({ storeId, customers: data, cachedAt: Date.now() });
       }
     })();
-  }, [currentStore?.store_id]);
+  }, [currentStore?.store_id, isOnline]);
 
   const searchCustomers = async (query: string) => {
     if (!currentStore) {
@@ -77,17 +83,24 @@ export const useCustomers = () => {
       setCustomers(data || []);
     } catch (error) {
       console.error('Error searching customers:', error);
+      let cacheFallbackSucceeded = false;
       try {
         const cached = await offlineDb.cachedCustomers.get(currentStore.store_id);
         setCustomers(filterCachedCustomers(cached?.customers ?? [], query));
+        cacheFallbackSucceeded = true;
       } catch {
         // no cache available either - fall through to the error toast below
       }
-      toast({
-        title: "Error",
-        description: "Failed to search customers",
-        variant: "destructive",
-      });
+      // Don't show a destructive "failed" toast when the cache fallback
+      // just displayed valid (if possibly stale) results - showing both
+      // at once told the user their search worked and failed simultaneously.
+      if (!cacheFallbackSucceeded) {
+        toast({
+          title: "Error",
+          description: "Failed to search customers",
+          variant: "destructive",
+        });
+      }
     } finally {
       setLoading(false);
     }

--- a/src/hooks/useOfflineOrderQueue.ts
+++ b/src/hooks/useOfflineOrderQueue.ts
@@ -1,0 +1,66 @@
+import { useLiveQuery } from 'dexie-react-hooks';
+import { offlineDb, type OfflineOrderPayload, type QueuedOfflineOrder } from '@/lib/offlineDb';
+import { authService } from '@/services/authService';
+
+export class OfflineSessionExpiredError extends Error {
+  constructor() {
+    super('Sesi Anda telah berakhir. Silakan login ulang untuk membuat pesanan offline baru.');
+    this.name = 'OfflineSessionExpiredError';
+  }
+}
+
+// Session expiry is checked here only as a courtesy gate on creating NEW
+// offline orders (an unattended terminal shouldn't be able to keep taking
+// orders past its session window). It has no bearing on whether an
+// already-queued order can sync - Supabase never sees this app-level
+// session at all (static anon key, RLS disabled), so sync proceeds
+// regardless of session state.
+export async function queueOfflineOrder(
+  storeId: string,
+  payload: OfflineOrderPayload
+): Promise<string> {
+  if (!authService.isAuthenticated()) {
+    throw new OfflineSessionExpiredError();
+  }
+
+  const id = crypto.randomUUID();
+  const record: QueuedOfflineOrder = {
+    id,
+    storeId,
+    payload,
+    needsPointsEarning: payload.payment_status === 'completed',
+    step: 'orders',
+    status: 'queued',
+    attempts: 0,
+    nextAttemptAt: null,
+    lastError: null,
+    queuedAt: Date.now(),
+    queuedByUserId: authService.getCurrentUser()?.id ?? 'unknown',
+    syncedAt: null,
+  };
+
+  await offlineDb.offlineOrderQueue.add(record);
+  return id;
+}
+
+// Resets a record to 'queued' so the scheduler (or an immediate manual
+// sync trigger) picks it up again - used for both a normal retryable
+// bump and a manual "try again" on an error_permanent row.
+export async function retryQueuedOrder(id: string): Promise<void> {
+  await offlineDb.offlineOrderQueue.update(id, {
+    status: 'queued',
+    nextAttemptAt: null,
+    lastError: null,
+  });
+}
+
+export const usePendingOrders = (storeId?: string) => {
+  const records = useLiveQuery(
+    () =>
+      storeId
+        ? offlineDb.offlineOrderQueue.where('storeId').equals(storeId).sortBy('queuedAt')
+        : offlineDb.offlineOrderQueue.orderBy('queuedAt').toArray(),
+    [storeId]
+  );
+  return records ?? [];
+};

--- a/src/hooks/useOfflineOrderQueue.ts
+++ b/src/hooks/useOfflineOrderQueue.ts
@@ -33,10 +33,10 @@ export async function queueOfflineOrder(
     status: 'queued',
     attempts: 0,
     nextAttemptAt: null,
+    syncStartedAt: null,
     lastError: null,
     queuedAt: Date.now(),
     queuedByUserId: authService.getCurrentUser()?.id ?? 'unknown',
-    syncedAt: null,
   };
 
   await offlineDb.offlineOrderQueue.add(record);
@@ -50,16 +50,21 @@ export async function retryQueuedOrder(id: string): Promise<void> {
   await offlineDb.offlineOrderQueue.update(id, {
     status: 'queued',
     nextAttemptAt: null,
+    syncStartedAt: null,
     lastError: null,
   });
 }
 
+// No storeId (StoreContext still loading, or no store selected) must never
+// fall back to querying every store's queue - that would briefly render
+// another store's customer names and order totals, breaking the
+// multi-tenant isolation this app requires everywhere else.
 export const usePendingOrders = (storeId?: string) => {
   const records = useLiveQuery(
     () =>
       storeId
         ? offlineDb.offlineOrderQueue.where('storeId').equals(storeId).sortBy('queuedAt')
-        : offlineDb.offlineOrderQueue.orderBy('queuedAt').toArray(),
+        : Promise.resolve([]),
     [storeId]
   );
   return records ?? [];

--- a/src/hooks/useOfflineOrderSync.ts
+++ b/src/hooks/useOfflineOrderSync.ts
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { offlineDb, type QueuedOfflineOrder, type OfflineOrderError, type OfflineOrderStep } from '@/lib/offlineDb';
+import { retryQueuedOrder } from '@/hooks/useOfflineOrderQueue';
+import { computePointsEarned } from '@/lib/pointsCalculation';
 import { useWhatsApp } from '@/hooks/useWhatsApp';
 import { WhatsAppDataHelper } from '@/integrations/whatsapp/data-helper';
 import type { OrderCreatedData, NotificationResult } from '@/integrations/whatsapp/types';
@@ -9,25 +11,15 @@ type NotifyOrderCreated = (phoneNumber: string, orderData: OrderCreatedData) => 
 
 const BASE_DELAY_MS = 3000;
 const MAX_DELAY_MS = 300000;
+// If a record has been 'syncing' longer than this, the tab/app that set it
+// almost certainly died mid-attempt (nothing else holds it that long) -
+// treat it as abandoned and let another attempt reclaim it. The per-record
+// Web Lock still protects against a genuinely-still-running attempt.
+const STALE_SYNCING_MS = 2 * 60 * 1000;
 
 function backoffDelay(attempts: number): number {
   const capped = Math.min(BASE_DELAY_MS * 2 ** Math.max(attempts - 1, 0), MAX_DELAY_MS);
   return Math.round(Math.random() * capped);
-}
-
-function computePointsEarned(items: QueuedOfflineOrder['payload']['items']): number {
-  let total = 0;
-  for (const item of items) {
-    if (item.service_type === 'kilo' && item.weight_kg) {
-      total += Math.round(item.weight_kg);
-    } else if (item.service_type === 'unit') {
-      total += Math.ceil(item.quantity);
-    } else if (item.service_type === 'combined') {
-      if (item.weight_kg) total += Math.round(item.weight_kg);
-      total += Math.ceil(item.quantity);
-    }
-  }
-  return total;
 }
 
 class RetryableSyncError extends Error {
@@ -43,15 +35,29 @@ class PermanentSyncError extends Error {
   }
 }
 
-// A Postgres error surfaced by supabase-js always carries a `code`
-// (the Postgres error code, e.g. '23505'). A transport failure (dropped
-// connection, timeout, CORS) never does - that distinction is what
-// separates "safe to retry forever" from "stop and ask a human".
+// Only a known set of data-level Postgres error codes are treated as
+// permanent (genuine schema/constraint anomalies a retry can never fix).
+// Everything else - no code at all (a transport failure), or a code we
+// don't recognize (including PostgREST gateway codes like PGRST000/503
+// and system codes like ENOTFOUND/ECONNREFUSED that some supabase-js
+// versions surface for real network failures) - is retryable. Getting
+// this wrong in the other direction would strand orders in
+// error_permanent on a transient blip, defeating the point of the
+// feature: keep retrying until connectivity actually returns.
+const PERMANENT_ERROR_CODES = new Set([
+  '23505', // unique_violation (outside the orders-insert path, which handles its own expected 23505 before this is ever called)
+  '23503', // foreign_key_violation
+  '23514', // check_violation
+  '42703', // undefined_column
+  '42P01', // undefined_table
+  '22P02', // invalid_text_representation
+]);
+
 function throwClassified(error: { code?: string; message?: string }, step: OfflineOrderStep): never {
-  if (!error.code) {
-    throw new RetryableSyncError(error.message || 'Network error');
+  if (error.code && PERMANENT_ERROR_CODES.has(error.code)) {
+    throw new PermanentSyncError(error.message || `Postgres error ${error.code}`, error.code);
   }
-  throw new PermanentSyncError(error.message || `Postgres error ${error.code}`, error.code);
+  throw new RetryableSyncError(error.message || 'Network error');
 }
 
 async function sendOfflineOrderNotification(
@@ -98,6 +104,7 @@ async function processQueuedOrder(
   await offlineDb.offlineOrderQueue.update(record.id, {
     status: 'syncing',
     attempts: record.attempts + 1,
+    syncStartedAt: Date.now(),
   });
 
   let step = record.step;
@@ -188,11 +195,19 @@ async function processQueuedOrder(
         // Re-check enable_points live against this order's store (not
         // necessarily the currently-selected store in the UI) - the
         // queue-time snapshot could be stale by the time this syncs.
-        const { data: storeRow } = await supabase
+        const { data: storeRow, error: storeError } = await supabase
           .from('stores')
           .select('enable_points')
           .eq('id', record.storeId)
           .maybeSingle();
+
+        // A failed read here must not silently skip points forever - fail
+        // the same way every other Supabase call in this function does, so
+        // it retries instead of quietly advancing past 'done' and deleting
+        // a record whose points were never actually evaluated.
+        if (storeError) {
+          throwClassified(storeError, 'points_earning');
+        }
 
         if (storeRow?.enable_points) {
           pointsEarned = computePointsEarned(record.payload.items);
@@ -234,6 +249,11 @@ async function processQueuedOrder(
       message: err instanceof Error ? err.message : 'Unknown error',
       at: Date.now(),
     };
+    // Raw Postgres/network error text is kept here for diagnosis - the UI
+    // only ever renders a fixed, generic message from this record's step,
+    // never errorInfo.message itself, per the "don't expose internal
+    // errors to users" guideline.
+    console.error(`Offline order sync failed for ${record.id} at step "${step}":`, err);
 
     if (err instanceof RetryableSyncError) {
       const latest = await offlineDb.offlineOrderQueue.get(record.id);
@@ -241,11 +261,13 @@ async function processQueuedOrder(
       await offlineDb.offlineOrderQueue.update(record.id, {
         status: 'error_retryable',
         nextAttemptAt: Date.now() + backoffDelay(attempts),
+        syncStartedAt: null,
         lastError: errorInfo,
       });
     } else {
       await offlineDb.offlineOrderQueue.update(record.id, {
         status: 'error_permanent',
+        syncStartedAt: null,
         lastError: errorInfo,
       });
     }
@@ -271,19 +293,26 @@ async function processQueuedOrderLocked(
 
 let syncInFlight = false;
 
-// Processes every due record (queued, or error_retryable whose backoff has
-// elapsed) across ALL stores on this device - sequentially, oldest first,
-// so switching stores never strands a queued order and a flaky connection
-// isn't hammered with concurrent retries.
+// Processes every due record - queued, error_retryable whose backoff has
+// elapsed, or 'syncing' abandoned long enough to reclaim (the tab/app
+// that started it almost certainly died mid-attempt) - across ALL stores
+// on this device, sequentially, oldest first, so switching stores never
+// strands a queued order and a flaky connection isn't hammered with
+// concurrent retries.
 export async function triggerOfflineSync(notifyOrderCreated: NotifyOrderCreated): Promise<void> {
   if (syncInFlight || !navigator.onLine) return;
   syncInFlight = true;
   try {
     const now = Date.now();
     const due = (
-      await offlineDb.offlineOrderQueue.where('status').anyOf('queued', 'error_retryable').toArray()
+      await offlineDb.offlineOrderQueue.where('status').anyOf('queued', 'error_retryable', 'syncing').toArray()
     )
-      .filter((r) => r.nextAttemptAt === null || r.nextAttemptAt <= now)
+      .filter((r) => {
+        if (r.status === 'syncing') {
+          return r.syncStartedAt !== null && now - r.syncStartedAt > STALE_SYNCING_MS;
+        }
+        return r.nextAttemptAt === null || r.nextAttemptAt <= now;
+      })
       .sort((a, b) => a.queuedAt - b.queuedAt);
 
     for (const record of due) {
@@ -299,7 +328,7 @@ export async function triggerOfflineSync(notifyOrderCreated: NotifyOrderCreated)
 // error_permanent rows a staff member wants to try again) and syncs it
 // immediately rather than waiting for the next scheduler tick.
 export async function retryOfflineOrderNow(id: string, notifyOrderCreated: NotifyOrderCreated): Promise<void> {
-  await offlineDb.offlineOrderQueue.update(id, { status: 'queued', nextAttemptAt: null, lastError: null });
+  await retryQueuedOrder(id);
   const fresh = await offlineDb.offlineOrderQueue.get(id);
   if (fresh) {
     await processQueuedOrderLocked(fresh, notifyOrderCreated);
@@ -312,7 +341,10 @@ export async function retryOfflineOrderNow(id: string, notifyOrderCreated: Notif
 export const useOfflineOrderSync = () => {
   const { notifyOrderCreated } = useWhatsApp();
   const notifyRef = useRef(notifyOrderCreated);
-  notifyRef.current = notifyOrderCreated;
+
+  useEffect(() => {
+    notifyRef.current = notifyOrderCreated;
+  }, [notifyOrderCreated]);
 
   const runSync = useCallback(() => {
     void triggerOfflineSync(notifyRef.current);

--- a/src/hooks/useOfflineOrderSync.ts
+++ b/src/hooks/useOfflineOrderSync.ts
@@ -1,0 +1,342 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { supabase } from '@/integrations/supabase/client';
+import { offlineDb, type QueuedOfflineOrder, type OfflineOrderError, type OfflineOrderStep } from '@/lib/offlineDb';
+import { useWhatsApp } from '@/hooks/useWhatsApp';
+import { WhatsAppDataHelper } from '@/integrations/whatsapp/data-helper';
+import type { OrderCreatedData, NotificationResult } from '@/integrations/whatsapp/types';
+
+type NotifyOrderCreated = (phoneNumber: string, orderData: OrderCreatedData) => Promise<NotificationResult>;
+
+const BASE_DELAY_MS = 3000;
+const MAX_DELAY_MS = 300000;
+
+function backoffDelay(attempts: number): number {
+  const capped = Math.min(BASE_DELAY_MS * 2 ** Math.max(attempts - 1, 0), MAX_DELAY_MS);
+  return Math.round(Math.random() * capped);
+}
+
+function computePointsEarned(items: QueuedOfflineOrder['payload']['items']): number {
+  let total = 0;
+  for (const item of items) {
+    if (item.service_type === 'kilo' && item.weight_kg) {
+      total += Math.round(item.weight_kg);
+    } else if (item.service_type === 'unit') {
+      total += Math.ceil(item.quantity);
+    } else if (item.service_type === 'combined') {
+      if (item.weight_kg) total += Math.round(item.weight_kg);
+      total += Math.ceil(item.quantity);
+    }
+  }
+  return total;
+}
+
+class RetryableSyncError extends Error {
+  retryable = true as const;
+}
+
+class PermanentSyncError extends Error {
+  permanent = true as const;
+  code: string | null;
+  constructor(message: string, code: string | null = null) {
+    super(message);
+    this.code = code;
+  }
+}
+
+// A Postgres error surfaced by supabase-js always carries a `code`
+// (the Postgres error code, e.g. '23505'). A transport failure (dropped
+// connection, timeout, CORS) never does - that distinction is what
+// separates "safe to retry forever" from "stop and ask a human".
+function throwClassified(error: { code?: string; message?: string }, step: OfflineOrderStep): never {
+  if (!error.code) {
+    throw new RetryableSyncError(error.message || 'Network error');
+  }
+  throw new PermanentSyncError(error.message || `Postgres error ${error.code}`, error.code);
+}
+
+async function sendOfflineOrderNotification(
+  record: QueuedOfflineOrder,
+  pointsEarned: number,
+  notifyOrderCreated: NotifyOrderCreated
+): Promise<void> {
+  try {
+    const { data: storeRow } = await supabase
+      .from('stores')
+      .select('name, address, phone, enable_qr, enable_points, wa_use_store_number, wa_sender_id')
+      .eq('id', record.storeId)
+      .maybeSingle();
+
+    const storeInfo = WhatsAppDataHelper.getStoreInfoFromContext(storeRow);
+    const orderItems = WhatsAppDataHelper.formatOrderItems(record.payload.items);
+
+    const notificationData: OrderCreatedData = {
+      orderId: record.id,
+      customerName: record.payload.customer_name,
+      totalAmount: record.payload.total_amount,
+      subtotal: record.payload.subtotal,
+      estimatedCompletion: WhatsAppDataHelper.formatEstimatedCompletion(record.payload.estimated_completion),
+      paymentStatus: record.payload.payment_status || 'pending',
+      orderItems,
+      storeInfo,
+      pointsEarned: pointsEarned > 0 ? pointsEarned : undefined,
+      discountAmount: record.payload.discount_amount && record.payload.discount_amount > 0 ? record.payload.discount_amount : undefined,
+    };
+
+    await notifyOrderCreated(record.payload.customer_phone, notificationData);
+  } catch (error) {
+    // Notification failures never affect sync status - the order is
+    // already durably saved server-side by the time this runs.
+    console.warn('Offline order synced but WhatsApp notification failed:', error);
+  }
+}
+
+async function processQueuedOrder(
+  record: QueuedOfflineOrder,
+  notifyOrderCreated: NotifyOrderCreated
+): Promise<void> {
+  const startingStep = record.step;
+  await offlineDb.offlineOrderQueue.update(record.id, {
+    status: 'syncing',
+    attempts: record.attempts + 1,
+  });
+
+  let step = record.step;
+  let pointsEarned = 0;
+
+  try {
+    if (step === 'orders') {
+      const { error } = await supabase.from('orders').insert({
+        id: record.id,
+        store_id: record.storeId,
+        customer_name: record.payload.customer_name,
+        customer_phone: record.payload.customer_phone,
+        subtotal: record.payload.subtotal,
+        tax_amount: record.payload.tax_amount,
+        total_amount: record.payload.total_amount,
+        discount_amount: record.payload.discount_amount || 0,
+        execution_status: record.payload.execution_status || 'in_queue',
+        payment_status: record.payload.payment_status || 'pending',
+        payment_method: record.payload.payment_method,
+        payment_amount: record.payload.payment_amount,
+        cash_received: record.payload.cash_received,
+        payment_notes: record.payload.payment_notes,
+        order_date: record.payload.order_date || new Date(record.queuedAt).toISOString(),
+        estimated_completion: record.payload.estimated_completion,
+      });
+
+      if (error) {
+        if (error.code === '23505') {
+          // Our own prior attempt likely landed before the response
+          // reached the client - confirm it's actually this order before
+          // treating the conflict as success.
+          const { data: existing } = await supabase
+            .from('orders')
+            .select('id, store_id')
+            .eq('id', record.id)
+            .maybeSingle();
+          if (!existing || existing.store_id !== record.storeId) {
+            throw new PermanentSyncError('Order id collision with an unrelated order', error.code);
+          }
+          // fall through - confirmed already inserted by us
+        } else {
+          throwClassified(error, 'orders');
+        }
+      }
+
+      step = 'order_items';
+      await offlineDb.offlineOrderQueue.update(record.id, { step });
+    }
+
+    if (step === 'order_items') {
+      const { data: existingItems, error: existingError } = await supabase
+        .from('order_items')
+        .select('id')
+        .eq('order_id', record.id)
+        .limit(1);
+
+      if (existingError) {
+        throwClassified(existingError, 'order_items');
+      }
+
+      if (!existingItems || existingItems.length === 0) {
+        const orderItems = record.payload.items.map((item) => ({
+          order_id: record.id,
+          service_name: item.service_name,
+          service_price: item.service_price,
+          quantity: Math.ceil(item.quantity),
+          line_total: item.service_price * item.quantity,
+          service_type: item.service_type,
+          weight_kg: item.weight_kg,
+          unit_items: item.service_type === 'kilo' ? 0 : item.unit_items,
+          estimated_completion: item.estimated_completion,
+          category: item.category,
+          item_type: item.item_type || 'service',
+        }));
+
+        const { error } = await supabase.from('order_items').insert(orderItems);
+        if (error) {
+          throwClassified(error, 'order_items');
+        }
+      }
+
+      step = 'points_earning';
+      await offlineDb.offlineOrderQueue.update(record.id, { step });
+    }
+
+    if (step === 'points_earning') {
+      if (record.needsPointsEarning) {
+        // Re-check enable_points live against this order's store (not
+        // necessarily the currently-selected store in the UI) - the
+        // queue-time snapshot could be stale by the time this syncs.
+        const { data: storeRow } = await supabase
+          .from('stores')
+          .select('enable_points')
+          .eq('id', record.storeId)
+          .maybeSingle();
+
+        if (storeRow?.enable_points) {
+          pointsEarned = computePointsEarned(record.payload.items);
+          if (pointsEarned > 0) {
+            const { error } = await supabase.rpc('award_points_for_synced_order', {
+              p_order_id: record.id,
+              p_store_id: record.storeId,
+              p_customer_phone: record.payload.customer_phone,
+              p_points_earned: pointsEarned,
+            });
+            if (error) {
+              throwClassified(error, 'points_earning');
+            }
+          }
+        }
+      }
+
+      step = 'done';
+      await offlineDb.offlineOrderQueue.update(record.id, { step });
+    }
+
+    // Only the run that actually causes the step transition into 'done'
+    // notifies - a resumed run that starts with step already 'done' (crash
+    // between marking done and deleting the record below) must not
+    // re-send WhatsApp.
+    if (startingStep !== 'done') {
+      void sendOfflineOrderNotification(record, pointsEarned, notifyOrderCreated);
+    }
+
+    // Once synced, this record has nothing left to do - the order now
+    // lives in Supabase and shows up in Order History like any other.
+    // Deleting it (rather than marking a terminal 'synced' status) keeps
+    // the local queue from growing unbounded across a device's lifetime.
+    await offlineDb.offlineOrderQueue.delete(record.id);
+  } catch (err) {
+    const errorInfo: OfflineOrderError = {
+      step,
+      code: err instanceof PermanentSyncError ? err.code : null,
+      message: err instanceof Error ? err.message : 'Unknown error',
+      at: Date.now(),
+    };
+
+    if (err instanceof RetryableSyncError) {
+      const latest = await offlineDb.offlineOrderQueue.get(record.id);
+      const attempts = latest?.attempts ?? record.attempts + 1;
+      await offlineDb.offlineOrderQueue.update(record.id, {
+        status: 'error_retryable',
+        nextAttemptAt: Date.now() + backoffDelay(attempts),
+        lastError: errorInfo,
+      });
+    } else {
+      await offlineDb.offlineOrderQueue.update(record.id, {
+        status: 'error_permanent',
+        lastError: errorInfo,
+      });
+    }
+  }
+}
+
+async function processQueuedOrderLocked(
+  record: QueuedOfflineOrder,
+  notifyOrderCreated: NotifyOrderCreated
+): Promise<void> {
+  if (typeof navigator === 'undefined' || !('locks' in navigator)) {
+    await processQueuedOrder(record, notifyOrderCreated);
+    return;
+  }
+
+  await navigator.locks.request(`offline-order-sync:${record.id}`, { ifAvailable: true }, async (lock) => {
+    if (!lock) return; // another tab already holds it - skip this record this tick
+    const fresh = await offlineDb.offlineOrderQueue.get(record.id);
+    if (!fresh) return; // already synced (and deleted) by another tab
+    await processQueuedOrder(fresh, notifyOrderCreated);
+  });
+}
+
+let syncInFlight = false;
+
+// Processes every due record (queued, or error_retryable whose backoff has
+// elapsed) across ALL stores on this device - sequentially, oldest first,
+// so switching stores never strands a queued order and a flaky connection
+// isn't hammered with concurrent retries.
+export async function triggerOfflineSync(notifyOrderCreated: NotifyOrderCreated): Promise<void> {
+  if (syncInFlight || !navigator.onLine) return;
+  syncInFlight = true;
+  try {
+    const now = Date.now();
+    const due = (
+      await offlineDb.offlineOrderQueue.where('status').anyOf('queued', 'error_retryable').toArray()
+    )
+      .filter((r) => r.nextAttemptAt === null || r.nextAttemptAt <= now)
+      .sort((a, b) => a.queuedAt - b.queuedAt);
+
+    for (const record of due) {
+      if (!navigator.onLine) break;
+      await processQueuedOrderLocked(record, notifyOrderCreated);
+    }
+  } finally {
+    syncInFlight = false;
+  }
+}
+
+// Manual retry entry point for the UI - resets the record (including
+// error_permanent rows a staff member wants to try again) and syncs it
+// immediately rather than waiting for the next scheduler tick.
+export async function retryOfflineOrderNow(id: string, notifyOrderCreated: NotifyOrderCreated): Promise<void> {
+  await offlineDb.offlineOrderQueue.update(id, { status: 'queued', nextAttemptAt: null, lastError: null });
+  const fresh = await offlineDb.offlineOrderQueue.get(id);
+  if (fresh) {
+    await processQueuedOrderLocked(fresh, notifyOrderCreated);
+  }
+}
+
+// Mounted once at the app root. Wires the unified sync trigger set: the
+// `online` event, tab focus/visibility, and a foreground poll - no
+// Background Sync API (unsupported in Safari/iOS, which this app targets).
+export const useOfflineOrderSync = () => {
+  const { notifyOrderCreated } = useWhatsApp();
+  const notifyRef = useRef(notifyOrderCreated);
+  notifyRef.current = notifyOrderCreated;
+
+  const runSync = useCallback(() => {
+    void triggerOfflineSync(notifyRef.current);
+  }, []);
+
+  useEffect(() => {
+    runSync();
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') runSync();
+    };
+
+    window.addEventListener('online', runSync);
+    window.addEventListener('focus', runSync);
+    document.addEventListener('visibilitychange', handleVisibility);
+    const interval = setInterval(runSync, 30000);
+
+    return () => {
+      window.removeEventListener('online', runSync);
+      window.removeEventListener('focus', runSync);
+      document.removeEventListener('visibilitychange', handleVisibility);
+      clearInterval(interval);
+    };
+  }, [runSync]);
+
+  return { syncNow: runSync };
+};

--- a/src/hooks/useOnlineStatus.ts
+++ b/src/hooks/useOnlineStatus.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+
+export const useOnlineStatus = (): boolean => {
+  const [isOnline, setIsOnline] = useState(navigator.onLine);
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+};

--- a/src/hooks/useOrdersOptimized.ts
+++ b/src/hooks/useOrdersOptimized.ts
@@ -3,7 +3,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { useStore } from '@/contexts/StoreContext';
 
-interface UnitItem {
+export interface UnitItem {
   item_name: string;
   quantity: number;
   price_per_unit: number;
@@ -42,7 +42,7 @@ interface Order {
   order_items: OrderItem[];
 }
 
-interface CreateOrderData {
+export interface CreateOrderData {
   customer_name: string;
   customer_phone: string;
   items: {

--- a/src/hooks/useOrdersOptimized.ts
+++ b/src/hooks/useOrdersOptimized.ts
@@ -466,4 +466,4 @@ export const useOrdersByCustomer = (customerPhone: string) => {
   });
 };
 
-export type { Order, OrderItem, UnitItem, CreateOrderData, OrderFilters };
+export type { Order, OrderItem, OrderFilters };

--- a/src/hooks/useOrdersWithNotifications.ts
+++ b/src/hooks/useOrdersWithNotifications.ts
@@ -8,6 +8,7 @@ import { WhatsAppDataHelper } from '@/integrations/whatsapp/data-helper';
 import { OrderCreatedData, OrderCompletedData, OrderReadyForPickupData, PaymentConfirmationData } from '@/integrations/whatsapp/types';
 import type { CreateOrderData, UnitItem } from './useOrdersOptimized';
 import { POINTS_TO_CURRENCY_RATE } from '@/components/orders/PayLaterPaymentDialog';
+import { computePointsEarned } from '@/lib/pointsCalculation';
 
 // Re-export types for convenience
 export type { CreateOrderData, UnitItem };
@@ -122,28 +123,14 @@ export const useCreateOrderWithNotifications = () => {
       let pointsEarned = 0;
       if (orderData.payment_status === 'completed' && currentStore?.enable_points) {
         // Calculate points from the orderItems that were actually inserted
-        orderItems.forEach(item => {
-          if (item.service_type === 'kilo' && item.weight_kg) {
-            // 1 point per kg (rounded)
-            pointsEarned += Math.round(item.weight_kg);
-          } else if (item.service_type === 'unit') {
-            // 1 point per unit (quantity is already rounded up at line 52)
-            pointsEarned += item.quantity;
-          } else if (item.service_type === 'combined') {
-            // For combined, count both weight and units
-            if (item.weight_kg) {
-              pointsEarned += Math.round(item.weight_kg);
-            }
-            pointsEarned += item.quantity;
-          }
-        });
+        pointsEarned = computePointsEarned(orderItems);
 
         if (pointsEarned > 0) {
           // Atomic RPC: does the guard + points upsert + ledger insert as a
           // single transaction, closing the race the old read-then-write
           // sequence had (two concurrent completions for the same new
           // customer could double-insert a points row).
-          const { error: awardError } = await supabase.rpc('award_points_for_synced_order', {
+          const { data: awardResult, error: awardError } = await supabase.rpc('award_points_for_synced_order', {
             p_order_id: order.id,
             p_store_id: currentStore?.store_id,
             p_customer_phone: orderData.customer_phone,
@@ -151,7 +138,20 @@ export const useCreateOrderWithNotifications = () => {
           });
 
           if (awardError) {
+            // The order itself is already saved - only the points award
+            // failed. Reset to 0 so the success dialog and WhatsApp message
+            // never claim points that were never actually credited.
             console.error('Error awarding points:', awardError);
+            pointsEarned = 0;
+            toast({
+              title: 'Poin Gagal Ditambahkan',
+              description: 'Pesanan tersimpan, tetapi poin pelanggan gagal ditambahkan.',
+              variant: 'destructive',
+            });
+          } else if (Array.isArray(awardResult) && awardResult[0]?.awarded === false) {
+            // Guard did not match (already awarded for this order id) -
+            // nothing new was credited this call.
+            pointsEarned = 0;
           }
         }
       }

--- a/src/hooks/useOrdersWithNotifications.ts
+++ b/src/hooks/useOrdersWithNotifications.ts
@@ -139,62 +139,19 @@ export const useCreateOrderWithNotifications = () => {
         });
 
         if (pointsEarned > 0) {
-          // Update order with points earned
-          await supabase
-            .from('orders')
-            .update({ points_earned: pointsEarned })
-            .eq('id', order.id);
+          // Atomic RPC: does the guard + points upsert + ledger insert as a
+          // single transaction, closing the race the old read-then-write
+          // sequence had (two concurrent completions for the same new
+          // customer could double-insert a points row).
+          const { error: awardError } = await supabase.rpc('award_points_for_synced_order', {
+            p_order_id: order.id,
+            p_store_id: currentStore?.store_id,
+            p_customer_phone: orderData.customer_phone,
+            p_points_earned: pointsEarned,
+          });
 
-          // Update points table (existing table in the database)
-          const { data: existingPoints } = await supabase
-            .from('points')
-            .select('point_id, accumulated_points, current_points')
-            .eq('customer_phone', orderData.customer_phone)
-            .eq('store_id', currentStore?.store_id)
-            .single();
-
-          let pointId: number;
-
-          if (existingPoints) {
-            // Add to existing points
-            await supabase
-              .from('points')
-              .update({ 
-                accumulated_points: existingPoints.accumulated_points + pointsEarned,
-                current_points: existingPoints.current_points + pointsEarned,
-                updated_at: new Date().toISOString(),
-              })
-              .eq('point_id', existingPoints.point_id);
-            
-            pointId = existingPoints.point_id;
-          } else {
-            // Create new customer points record
-            const { data: newPoint } = await supabase
-              .from('points')
-              .insert({
-                customer_phone: orderData.customer_phone,
-                accumulated_points: pointsEarned,
-                current_points: pointsEarned,
-                store_id: currentStore?.store_id,
-              })
-              .select('point_id')
-              .single();
-            
-            pointId = newPoint?.point_id;
-          }
-
-          // Create point transaction record for earning points
-          if (pointId) {
-            await supabase
-              .from('point_transactions')
-              .insert({
-                point_id: pointId,
-                order_id: order.id,
-                points_changed: pointsEarned,
-                transaction_type: 'earning',
-                transaction_date: new Date().toISOString(),
-                notes: `Points earned from order ${order.id.slice(0, 8)}`,
-              });
+          if (awardError) {
+            console.error('Error awarding points:', awardError);
           }
         }
       }

--- a/src/hooks/useServices.ts
+++ b/src/hooks/useServices.ts
@@ -1,7 +1,9 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useLiveQuery } from 'dexie-react-hooks';
 import { supabase } from '@/integrations/supabase/client';
 import { useStore } from '@/contexts/StoreContext';
 import { useToast } from './use-toast';
+import { offlineDb } from '@/lib/offlineDb';
 
 // Service data interface matching the database schema
 export interface ServiceData {
@@ -83,15 +85,26 @@ export const useServices = (category?: string) => {
   return useQuery({
     queryKey: ['services', currentStore?.store_id, category],
     queryFn: async (): Promise<ServiceData[]> => {
-      if (!currentStore?.store_id) {
+      const storeId = currentStore?.store_id;
+      if (!storeId) {
         throw new Error('No store selected');
+      }
+
+      const readCachedServices = async (): Promise<ServiceData[]> => {
+        const cached = await offlineDb.cachedServices.get(storeId);
+        const services = cached?.services ?? [];
+        return category ? services.filter((s) => s.category === category) : services;
+      };
+
+      if (!navigator.onLine) {
+        return readCachedServices();
       }
 
       try {
         let query = supabase
           .from('services')
           .select('*')
-          .eq('store_id', currentStore.store_id)
+          .eq('store_id', storeId)
           .eq('is_active', true)
           .order('name', { ascending: true });
 
@@ -106,16 +119,33 @@ export const useServices = (category?: string) => {
           throw error;
         }
 
-        return data || [];
+        const services = data || [];
+        // Write-through the full-catalog fetch into the offline cache so
+        // order creation still has last-known prices when connectivity
+        // drops. Skipped for category-scoped queries so the cache always
+        // holds the complete catalog, not a partial slice.
+        if (!category) {
+          offlineDb.cachedServices.put({ storeId, services, cachedAt: Date.now() }).catch(() => {});
+        }
+        return services;
       } catch (error) {
         console.error('Error in useServices:', error);
-        // If database fetch fails, return empty array instead of mock data
-        return [];
+        return readCachedServices();
       }
     },
     enabled: !!currentStore?.store_id,
     staleTime: 5 * 60 * 1000, // 5 minutes
   });
+};
+
+// Reads when the current store's service catalog was last cached for
+// offline use, so the UI can show "prices as of [time]" while offline.
+export const useCachedServicesMeta = (storeId?: string) => {
+  const cached = useLiveQuery(
+    () => (storeId ? offlineDb.cachedServices.get(storeId) : undefined),
+    [storeId]
+  );
+  return cached?.cachedAt ?? null;
 };
 
 // Hook to fetch services by category

--- a/src/lib/offlineDb.ts
+++ b/src/lib/offlineDb.ts
@@ -30,10 +30,13 @@ export interface QueuedOfflineOrder {
   status: OfflineOrderStatus;
   attempts: number;
   nextAttemptAt: number | null; // epoch ms; scheduler ignores the record until Date.now() >= this
+  // epoch ms set when status becomes 'syncing'. If the tab/app dies mid-sync,
+  // this is what lets the scheduler notice a record has been stuck in
+  // 'syncing' too long and reclaim it rather than leaving it stranded forever.
+  syncStartedAt: number | null;
   lastError: OfflineOrderError | null;
   queuedAt: number; // epoch ms, used for FIFO processing order
   queuedByUserId: string;
-  syncedAt: number | null;
 }
 
 export interface CachedServices {

--- a/src/lib/offlineDb.ts
+++ b/src/lib/offlineDb.ts
@@ -1,0 +1,66 @@
+import Dexie, { type Table } from 'dexie';
+import type { CreateOrderData } from '@/hooks/useOrdersOptimized';
+import type { ServiceData } from '@/hooks/useServices';
+import type { Customer } from '@/hooks/useCustomers';
+
+// Offline order payload never carries points_redeemed - points redemption is
+// disabled entirely for offline-created orders (client can never validate a
+// points balance it doesn't have a live read on).
+export type OfflineOrderPayload = Omit<CreateOrderData, 'points_redeemed'>;
+
+export type OfflineOrderStep = 'orders' | 'order_items' | 'points_earning' | 'done';
+// No terminal 'synced' state: a successfully-synced record is deleted
+// outright (see useOfflineOrderSync) rather than kept around - it now
+// lives in Supabase and shows up in Order History like any other order.
+export type OfflineOrderStatus = 'queued' | 'syncing' | 'error_retryable' | 'error_permanent';
+
+export interface OfflineOrderError {
+  step: OfflineOrderStep;
+  code: string | null;
+  message: string;
+  at: number;
+}
+
+export interface QueuedOfflineOrder {
+  id: string; // == orders.id, crypto.randomUUID() at queue time (Dexie primary key)
+  storeId: string;
+  payload: OfflineOrderPayload;
+  needsPointsEarning: boolean; // captured at queue time from payment_status === 'completed'; re-checked against live enable_points at sync time
+  step: OfflineOrderStep;
+  status: OfflineOrderStatus;
+  attempts: number;
+  nextAttemptAt: number | null; // epoch ms; scheduler ignores the record until Date.now() >= this
+  lastError: OfflineOrderError | null;
+  queuedAt: number; // epoch ms, used for FIFO processing order
+  queuedByUserId: string;
+  syncedAt: number | null;
+}
+
+export interface CachedServices {
+  storeId: string; // primary key
+  services: ServiceData[];
+  cachedAt: number;
+}
+
+export interface CachedCustomers {
+  storeId: string; // primary key
+  customers: Customer[];
+  cachedAt: number;
+}
+
+class OfflineDatabase extends Dexie {
+  offlineOrderQueue!: Table<QueuedOfflineOrder, string>;
+  cachedServices!: Table<CachedServices, string>;
+  cachedCustomers!: Table<CachedCustomers, string>;
+
+  constructor() {
+    super('smart-laundry-pos-offline');
+    this.version(1).stores({
+      offlineOrderQueue: 'id, storeId, status, nextAttemptAt, queuedAt, [status+nextAttemptAt]',
+      cachedServices: 'storeId',
+      cachedCustomers: 'storeId',
+    });
+  }
+}
+
+export const offlineDb = new OfflineDatabase();

--- a/src/lib/pointsCalculation.ts
+++ b/src/lib/pointsCalculation.ts
@@ -1,0 +1,23 @@
+interface PointsEligibleItem {
+  service_type: 'unit' | 'kilo' | 'combined';
+  quantity: number;
+  weight_kg?: number;
+}
+
+// 1 point per KG (rounded) for kilo services, 1 point per unit for unit
+// services, both for combined. Shared by the online order-creation path
+// and the offline sync worker so the two can never silently diverge.
+export function computePointsEarned(items: PointsEligibleItem[]): number {
+  let total = 0;
+  for (const item of items) {
+    if (item.service_type === 'kilo' && item.weight_kg) {
+      total += Math.round(item.weight_kg);
+    } else if (item.service_type === 'unit') {
+      total += Math.ceil(item.quantity);
+    } else if (item.service_type === 'combined') {
+      if (item.weight_kg) total += Math.round(item.weight_kg);
+      total += Math.ceil(item.quantity);
+    }
+  }
+  return total;
+}

--- a/src/lib/printUtils.ts
+++ b/src/lib/printUtils.ts
@@ -1002,6 +1002,7 @@ export const buildReceiptDataFromLocalOrder = (
     orderDate: payload.order_date || new Date().toISOString(),
     items: payload.items.map((item) => ({
       ...item,
+      item_type: item.item_type || 'service',
       line_total: item.service_price * item.quantity,
     })),
     totalAmount: payload.total_amount || 0,

--- a/src/lib/printUtils.ts
+++ b/src/lib/printUtils.ts
@@ -1,6 +1,7 @@
 import { supabase } from '@/integrations/supabase/client';
 import { BleClient, BleService } from '@capacitor-community/bluetooth-le';
 import { Capacitor } from '@capacitor/core';
+import type { OfflineOrderPayload } from '@/lib/offlineDb';
 
 // Constants
 const IFRAME_RENDER_WAIT_MS = 1000;
@@ -948,6 +949,74 @@ export const printToThermalPrinter = async (
     console.error('Error printing to thermal printer:', error);
     throw error instanceof Error ? error : new Error('Failed to print to thermal printer');
   }
+};
+
+export interface LocalReceiptStoreInfo {
+  name: string;
+  address?: string;
+  phone?: string;
+  enable_qr?: boolean;
+}
+
+export interface LocalReceiptData {
+  storeName: string;
+  storeAddress: string;
+  storePhone: string;
+  customerName: string;
+  customerPhone: string;
+  orderId: string;
+  orderDate: string;
+  items: Array<OfflineOrderPayload['items'][number] & { line_total: number }>;
+  totalAmount: number;
+  subtotal: number;
+  taxAmount: number;
+  discountAmount: number;
+  pointsRedeemed: number;
+  paymentMethod: string;
+  paymentStatus: string;
+  paymentAmount: number | null;
+  executionStatus: string;
+  estimatedCompletion: string | null;
+  cashReceived: number | null;
+  enableQr: boolean;
+}
+
+/**
+ * Builds the same receipt shape fetchReceiptDataForThermal returns, but
+ * directly from an in-memory order that hasn't synced to Supabase yet
+ * (offline order creation - get_receipt_data is an RPC that requires a
+ * server-confirmed order, so it isn't reachable for these).
+ */
+export const buildReceiptDataFromLocalOrder = (
+  localOrderId: string,
+  payload: OfflineOrderPayload,
+  storeInfo: LocalReceiptStoreInfo
+): LocalReceiptData => {
+  return {
+    storeName: storeInfo.name || 'SMART LAUNDRY POS',
+    storeAddress: storeInfo.address || '',
+    storePhone: storeInfo.phone || '',
+    customerName: payload.customer_name || '',
+    customerPhone: payload.customer_phone || '',
+    orderId: localOrderId,
+    orderDate: payload.order_date || new Date().toISOString(),
+    items: payload.items.map((item) => ({
+      ...item,
+      line_total: item.service_price * item.quantity,
+    })),
+    totalAmount: payload.total_amount || 0,
+    subtotal: payload.subtotal || 0,
+    taxAmount: payload.tax_amount || 0,
+    discountAmount: payload.discount_amount || 0,
+    pointsRedeemed: 0,
+    paymentMethod: payload.payment_method || 'cash',
+    paymentStatus: payload.payment_status || 'pending',
+    paymentAmount: payload.payment_amount ?? null,
+    executionStatus: payload.execution_status || 'in_queue',
+    estimatedCompletion: payload.estimated_completion || null,
+    cashReceived: payload.cash_received ?? null,
+    enableQr: storeInfo.enable_qr || false,
+  };
 };
 
 /**

--- a/src/pages/OrderHistoryOptimized.tsx
+++ b/src/pages/OrderHistoryOptimized.tsx
@@ -21,6 +21,9 @@ import { formatDate, isDateOverdue } from '@/lib/utils';
 import { openReceiptForView, openReceiptForPrint, generateReceiptPDFFromUrl, sanitizeFilename } from '@/lib/printUtils';
 import { usePageTitle, updatePageTitleWithCount } from '@/hooks/usePageTitle';
 import { useStore } from '@/contexts/StoreContext';
+import { usePendingOrders } from '@/hooks/useOfflineOrderQueue';
+import { retryOfflineOrderNow } from '@/hooks/useOfflineOrderSync';
+import { useWhatsApp } from '@/hooks/useWhatsApp';
 import { toast } from 'sonner';
 import { DateRange } from 'react-day-picker';
 import { startOfDay, endOfDay, subDays, subMonths } from 'date-fns';
@@ -42,7 +45,10 @@ interface SortState {
 export const OrderHistory = () => {
   const navigate = useNavigate();
   usePageTitle('Riwayat Pesanan');
-  const { isOwner } = useStore();
+  const { isOwner, currentStore } = useStore();
+  const pendingOfflineOrders = usePendingOrders(currentStore?.store_id);
+  const { notifyOrderCreated } = useWhatsApp();
+  const [retryingOrderId, setRetryingOrderId] = useState<string | null>(null);
   const [searchParams] = useSearchParams();
   // Deep-link support (e.g. Home page's "Pesanan Batal" tile): ?status=cancelled
   // preselects the execution-status filter and widens the date range so
@@ -470,6 +476,15 @@ export const OrderHistory = () => {
     }
   }, [resendNotification]);
 
+  const handleRetryOfflineOrder = useCallback(async (id: string) => {
+    setRetryingOrderId(id);
+    try {
+      await retryOfflineOrderNow(id, notifyOrderCreated);
+    } finally {
+      setRetryingOrderId(null);
+    }
+  }, [notifyOrderCreated]);
+
   return (
     <div className="min-h-screen bg-gray-50 -mx-4 sm:-mx-6 lg:-mx-8 -my-8">
       <div className="space-y-2 sm:space-y-6 lg:space-y-8">
@@ -715,6 +730,54 @@ export const OrderHistory = () => {
                 </Popover>
               </div>
             </div>
+
+            {/* Pending Offline Sync - queued orders not yet in Supabase.
+                Sourced independently from Dexie, not the React Query cache,
+                since there's no optimistic-cache precedent in this codebase
+                to inject synthetic pages into the paginated order list. */}
+            {pendingOfflineOrders.length > 0 && (
+              <Card className="border-pos-warning/40 bg-pos-warning/5">
+                <CardHeader className="pb-3">
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <Clock className="h-4 w-4" />
+                    Menunggu Sinkronisasi ({pendingOfflineOrders.length})
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-2">
+                  {pendingOfflineOrders.map((order) => {
+                    const statusLabel: Record<string, string> = {
+                      queued: 'Menunggu sinkronisasi',
+                      syncing: 'Sedang sinkron...',
+                      error_retryable: 'Mencoba lagi otomatis',
+                      error_permanent: 'Gagal - perlu tindakan',
+                    };
+                    return (
+                      <div key={order.id} className="flex items-center justify-between gap-3 rounded-lg border p-3">
+                        <div className="min-w-0">
+                          <p className="truncate font-medium">{order.payload.customer_name}</p>
+                          <p className="text-sm text-muted-foreground">
+                            Rp{order.payload.total_amount.toLocaleString('id-ID')} · {statusLabel[order.status] || order.status}
+                          </p>
+                          {order.status === 'error_permanent' && order.lastError && (
+                            <p className="text-xs text-destructive">{order.lastError.message}</p>
+                          )}
+                        </div>
+                        {(order.status === 'error_permanent' || order.status === 'error_retryable') && (
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={retryingOrderId === order.id}
+                            onClick={() => handleRetryOfflineOrder(order.id)}
+                          >
+                            {retryingOrderId === order.id ? 'Mencoba...' : 'Coba Lagi'}
+                          </Button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </CardContent>
+              </Card>
+            )}
 
             {/* Payment Summary Cards - Owner Only */}
             {isOwner && <PaymentSummaryCards orders={filteredOrders} />}

--- a/src/pages/OrderHistoryOptimized.tsx
+++ b/src/pages/OrderHistoryOptimized.tsx
@@ -477,9 +477,16 @@ export const OrderHistory = () => {
   }, [resendNotification]);
 
   const handleRetryOfflineOrder = useCallback(async (id: string) => {
+    if (!navigator.onLine) {
+      toast.error('Tidak ada koneksi internet. Sinkronisasi akan berjalan otomatis saat koneksi kembali.');
+      return;
+    }
     setRetryingOrderId(id);
     try {
       await retryOfflineOrderNow(id, notifyOrderCreated);
+    } catch (error) {
+      console.error('Error retrying offline order:', id, error);
+      toast.error('Gagal menyinkronkan pesanan. Silakan coba lagi.');
     } finally {
       setRetryingOrderId(null);
     }
@@ -759,7 +766,9 @@ export const OrderHistory = () => {
                             Rp{order.payload.total_amount.toLocaleString('id-ID')} · {statusLabel[order.status] || order.status}
                           </p>
                           {order.status === 'error_permanent' && order.lastError && (
-                            <p className="text-xs text-destructive">{order.lastError.message}</p>
+                            <p className="text-xs text-destructive">
+                              Sinkronisasi gagal pada tahap {order.lastError.step}. Hubungi admin jika berulang.
+                            </p>
                           )}
                         </div>
                         {(order.status === 'error_permanent' || order.status === 'error_retryable') && (

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -381,7 +381,7 @@ class AuthService {
 
   async setStoreFeatureFlags(
     storeId: string,
-    flags: { enableQr: boolean; enablePoints: boolean }
+    flags: { enableQr: boolean; enablePoints: boolean; enableOfflineMode: boolean }
   ): Promise<void> {
     if (!this.isAuthenticated()) {
       throw new Error('User not authenticated');
@@ -392,6 +392,7 @@ class AuthService {
       target_store_id: storeId,
       p_enable_qr: flags.enableQr,
       p_enable_points: flags.enablePoints,
+      p_enable_offline_mode: flags.enableOfflineMode,
     });
 
     if (error) {

--- a/src/types/multi-tenant.ts
+++ b/src/types/multi-tenant.ts
@@ -10,6 +10,7 @@ export interface Store {
   is_active: boolean;
   enable_qr: boolean;
   enable_points: boolean;
+  enable_offline_mode: boolean;
   wa_use_store_number: boolean;
   wa_sender_id?: string | null;
   wa_sender_last_verified?: string | null;
@@ -40,6 +41,7 @@ export interface StoreWithOwnershipInfo {
   is_active: boolean;
   enable_qr: boolean;
   enable_points: boolean;
+  enable_offline_mode: boolean;
   wa_use_store_number: boolean;
   wa_sender_id?: string | null;
   wa_sender_last_verified?: string | null;

--- a/supabase/migrations/20260802000000_add_award_points_for_synced_order_rpc.sql
+++ b/supabase/migrations/20260802000000_add_award_points_for_synced_order_rpc.sql
@@ -1,0 +1,58 @@
+-- Atomic points-earning RPC, used by both the online order-creation path and
+-- the offline sync worker. Replaces the previous client-driven
+-- read-balance -> branch -> update/insert -> insert-transaction sequence,
+-- which had an unguarded race: two concurrent completions for the same new
+-- customer could both see "no existing points row" and both try to insert,
+-- or double-credit an existing balance. Doing it as one plpgsql function
+-- makes the whole sequence a single implicit transaction with an internal
+-- compare-and-swap guard, so calling it twice for the same order (retry
+-- after a dropped connection, two tabs syncing the same queued order) is a
+-- safe no-op the second time rather than a double-credit.
+CREATE OR REPLACE FUNCTION public.award_points_for_synced_order(
+  p_order_id UUID,
+  p_store_id UUID,
+  p_customer_phone TEXT,
+  p_points_earned INTEGER
+)
+RETURNS TABLE(awarded BOOLEAN, point_id INTEGER, current_points INTEGER) AS $$
+DECLARE
+  v_point_id INTEGER;
+  v_current_points INTEGER;
+BEGIN
+  -- Compare-and-swap guard: only the first caller to reach here for this
+  -- order (across retries, tabs, devices) gets past this UPDATE having
+  -- actually matched a row.
+  UPDATE public.orders
+  SET points_earned = p_points_earned
+  WHERE id = p_order_id
+    AND (points_earned IS NULL OR points_earned = 0)
+    AND p_points_earned > 0;
+
+  IF NOT FOUND THEN
+    RETURN QUERY SELECT false, NULL::INTEGER, NULL::INTEGER;
+    RETURN;
+  END IF;
+
+  INSERT INTO public.points (customer_phone, store_id, accumulated_points, current_points)
+  VALUES (p_customer_phone, p_store_id, p_points_earned, p_points_earned)
+  ON CONFLICT (customer_phone, store_id) DO UPDATE SET
+    accumulated_points = public.points.accumulated_points + p_points_earned,
+    current_points = public.points.current_points + p_points_earned,
+    updated_at = now()
+  RETURNING public.points.point_id, public.points.current_points INTO v_point_id, v_current_points;
+
+  INSERT INTO public.point_transactions (point_id, order_id, points_changed, transaction_type, notes)
+  VALUES (
+    v_point_id,
+    p_order_id,
+    p_points_earned,
+    'earning',
+    'Points earned from order ' || substr(p_order_id::TEXT, 1, 8)
+  );
+
+  RETURN QUERY SELECT true, v_point_id, v_current_points;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION public.award_points_for_synced_order(UUID, UUID, TEXT, INTEGER) IS
+  'Atomically awards points for a completed order. Safe to call more than once for the same order_id - the second call is a confirmed no-op via the points_earned guard on orders, not a double-credit.';

--- a/supabase/migrations/20260802000000_add_award_points_for_synced_order_rpc.sql
+++ b/supabase/migrations/20260802000000_add_award_points_for_synced_order_rpc.sql
@@ -33,13 +33,19 @@ BEGIN
     RETURN;
   END IF;
 
+  -- Inside ON CONFLICT DO UPDATE / RETURNING, the target table must be
+  -- referenced by its unqualified name (or an alias) - a schema-qualified
+  -- "public.points.column" here makes Postgres try to resolve "public" as
+  -- a range-table entry and fail with "missing FROM-clause entry for
+  -- table public". The bare "points." prefix still disambiguates against
+  -- the RETURNS TABLE columns of the same name.
   INSERT INTO public.points (customer_phone, store_id, accumulated_points, current_points)
   VALUES (p_customer_phone, p_store_id, p_points_earned, p_points_earned)
   ON CONFLICT (customer_phone, store_id) DO UPDATE SET
-    accumulated_points = public.points.accumulated_points + p_points_earned,
-    current_points = public.points.current_points + p_points_earned,
+    accumulated_points = points.accumulated_points + p_points_earned,
+    current_points = points.current_points + p_points_earned,
     updated_at = now()
-  RETURNING public.points.point_id, public.points.current_points INTO v_point_id, v_current_points;
+  RETURNING points.point_id, points.current_points INTO v_point_id, v_current_points;
 
   INSERT INTO public.point_transactions (point_id, order_id, points_changed, transaction_type, notes)
   VALUES (
@@ -52,7 +58,7 @@ BEGIN
 
   RETURN QUERY SELECT true, v_point_id, v_current_points;
 END;
-$$ LANGUAGE plpgsql;
+$$ LANGUAGE plpgsql SET search_path = public, pg_temp;
 
 COMMENT ON FUNCTION public.award_points_for_synced_order(UUID, UUID, TEXT, INTEGER) IS
   'Atomically awards points for a completed order. Safe to call more than once for the same order_id - the second call is a confirmed no-op via the points_earned guard on orders, not a double-credit.';

--- a/supabase/migrations/20260802000001_add_enable_offline_mode_to_stores.sql
+++ b/supabase/migrations/20260802000001_add_enable_offline_mode_to_stores.sql
@@ -1,0 +1,129 @@
+-- Add enable_offline_mode configuration to stores table.
+-- Mirrors the enable_points pattern (20251102000000_add_enable_points_to_stores.sql):
+-- opt-in per store, default off. When true, staff can create orders while
+-- offline on that store; they queue locally and sync automatically once
+-- connectivity returns. Scope is order creation only - no offline status
+-- or payment updates, no offline points redemption.
+
+ALTER TABLE public.stores ADD COLUMN IF NOT EXISTS enable_offline_mode BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX IF NOT EXISTS idx_stores_enable_offline_mode ON public.stores(enable_offline_mode);
+
+COMMENT ON COLUMN public.stores.enable_offline_mode IS 'Allow staff to create orders while offline for this store. Orders queue locally and sync automatically when connectivity returns. Order creation only - no offline status/payment updates or points redemption.';
+
+-- Extend get_user_stores_by_userid to return enable_offline_mode so the
+-- frontend (StoreContext -> StoreWithOwnershipInfo) can read it.
+DROP FUNCTION IF EXISTS public.get_user_stores_by_userid(UUID);
+
+CREATE OR REPLACE FUNCTION public.get_user_stores_by_userid(user_id UUID)
+RETURNS TABLE(
+  store_id UUID,
+  store_name TEXT,
+  store_description TEXT,
+  store_address TEXT,
+  store_phone TEXT,
+  store_email TEXT,
+  is_owner BOOLEAN,
+  is_active BOOLEAN,
+  enable_qr BOOLEAN,
+  enable_points BOOLEAN,
+  enable_offline_mode BOOLEAN,
+  wa_use_store_number BOOLEAN,
+  wa_sender_id VARCHAR(50),
+  wa_sender_last_verified TIMESTAMP WITH TIME ZONE
+) AS $$
+DECLARE
+  current_user_role TEXT;
+  current_user_store_id UUID;
+BEGIN
+  SELECT u.role, u.store_id INTO current_user_role, current_user_store_id
+  FROM public.users u
+  WHERE u.id = user_id;
+
+  IF current_user_role = 'laundry_owner' THEN
+    RETURN QUERY
+    SELECT
+      s.id AS store_id,
+      s.name,
+      s.description,
+      s.address,
+      s.phone,
+      s.email,
+      true as is_owner,
+      s.is_active,
+      COALESCE(s.enable_qr, false) as enable_qr,
+      COALESCE(s.enable_points, false) as enable_points,
+      COALESCE(s.enable_offline_mode, false) as enable_offline_mode,
+      COALESCE(s.wa_use_store_number, false) as wa_use_store_number,
+      s.wa_sender_id,
+      s.wa_sender_last_verified
+    FROM public.stores s
+    WHERE s.owner_id = user_id
+    ORDER BY s.created_at DESC;
+  ELSE
+    RETURN QUERY
+    SELECT
+      s.id AS store_id,
+      s.name,
+      s.description,
+      s.address,
+      s.phone,
+      s.email,
+      false as is_owner,
+      s.is_active,
+      COALESCE(s.enable_qr, false) as enable_qr,
+      COALESCE(s.enable_points, false) as enable_points,
+      COALESCE(s.enable_offline_mode, false) as enable_offline_mode,
+      COALESCE(s.wa_use_store_number, false) as wa_use_store_number,
+      s.wa_sender_id,
+      s.wa_sender_last_verified
+    FROM public.stores s
+    WHERE s.id = current_user_store_id
+    AND s.is_active = true;
+  END IF;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.get_user_stores_by_userid IS 'Returns stores accessible by a user with enable_qr, enable_points, enable_offline_mode, wa_use_store_number, wa_sender_id, and wa_sender_last_verified fields for store features';
+
+-- Extend set_store_feature_flags to also set enable_offline_mode, same
+-- SECURITY DEFINER + ownership-check pattern (direct client .update() calls
+-- silently affect 0 rows under this app's custom auth).
+DROP FUNCTION IF EXISTS public.set_store_feature_flags(UUID, UUID, BOOLEAN, BOOLEAN);
+
+CREATE OR REPLACE FUNCTION public.set_store_feature_flags(
+  user_id UUID,
+  target_store_id UUID,
+  p_enable_qr BOOLEAN,
+  p_enable_points BOOLEAN,
+  p_enable_offline_mode BOOLEAN
+)
+RETURNS BOOLEAN AS $$
+DECLARE
+  store_owner_id UUID;
+BEGIN
+  SELECT owner_id INTO store_owner_id
+  FROM public.stores
+  WHERE id = target_store_id;
+
+  IF store_owner_id IS NULL THEN
+    RAISE EXCEPTION 'Store not found';
+  END IF;
+
+  IF store_owner_id <> user_id THEN
+    RAISE EXCEPTION 'Only the store owner can update this store';
+  END IF;
+
+  UPDATE public.stores
+  SET enable_qr = p_enable_qr,
+      enable_points = p_enable_points,
+      enable_offline_mode = p_enable_offline_mode,
+      updated_at = now()
+  WHERE id = target_store_id;
+
+  RETURN TRUE;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.set_store_feature_flags(UUID, UUID, BOOLEAN, BOOLEAN, BOOLEAN) IS
+  'Sets enable_qr, enable_points, and enable_offline_mode after verifying the caller owns the store.';

--- a/supabase/migrations/20260802000001_add_enable_offline_mode_to_stores.sql
+++ b/supabase/migrations/20260802000001_add_enable_offline_mode_to_stores.sql
@@ -82,7 +82,7 @@ BEGIN
     AND s.is_active = true;
   END IF;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp;
 
 COMMENT ON FUNCTION public.get_user_stores_by_userid IS 'Returns stores accessible by a user with enable_qr, enable_points, enable_offline_mode, wa_use_store_number, wa_sender_id, and wa_sender_last_verified fields for store features';
 
@@ -123,7 +123,7 @@ BEGIN
 
   RETURN TRUE;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public, pg_temp;
 
 COMMENT ON FUNCTION public.set_store_feature_flags(UUID, UUID, BOOLEAN, BOOLEAN, BOOLEAN) IS
   'Sets enable_qr, enable_points, and enable_offline_mode after verifying the caller owns the store.';


### PR DESCRIPTION
## Summary
- Store owners can opt in (Store Settings, default off) to let staff create orders while their store is offline. Orders queue locally in IndexedDB (Dexie) and sync automatically once connectivity returns, using a client-generated order id and a step-tracked queue record so retries after a dropped connection or app restart are idempotent and never double-insert.
- Scope is order creation only - status/payment updates still require connectivity, unchanged.
- Points redemption is disabled entirely for offline orders. Points earning is deferred to sync time via a new atomic `award_points_for_synced_order` RPC, which the online path now also uses - this closes a pre-existing race in the old read-then-write points logic where two concurrent completions for the same new customer could double-insert/double-credit.
- Service catalog and customer list are cached read-through so offline order creation still has last-known prices/customers; a "prices as of" cache timestamp is exposed for the UI.
- Sync is triggered by the `online` event, tab focus/visibility, and a foreground poll only - no Background Sync API, since Safari/iOS (an explicitly supported platform per this app's PWA install flow) never implemented it.
- Thermal receipt printing gets an in-memory path for offline orders, bypassing `get_receipt_data` (which requires a server-confirmed order).
- Order History shows a separate "Menunggu Sinkronisasi" section sourced from the local queue (not the paginated React Query cache), with manual retry for permanently-failed rows.

## Test plan
- [ ] Run the two new migrations against a dev Supabase project
- [ ] Toggle "Mode Offline" on for a test store in Store Settings
- [ ] With DevTools set to Offline: create a cash, non-cash, and draft order - confirm each appears in the pending-sync list, prints a receipt via the in-memory path, and shows no WhatsApp send yet; confirm points redemption UI is hidden even with points enabled
- [ ] Go back online - confirm auto-sync fires, orders land in real Order History, WhatsApp notification fires, and points are awarded for completed orders
- [ ] Force a permanent failure (e.g. delete the store before syncing) - confirm it surfaces as "gagal sinkron" rather than retrying forever, and manual retry works
- [ ] Two tabs open, both online simultaneously syncing the same queued order - confirm no duplicate `order_items` rows and exactly one `earning` row in `point_transactions`
- [ ] Expire the local session (edit `auth_session.expires_at` in localStorage) while offline - confirm new order creation is blocked with a re-login message, while already-queued orders still sync fine
- [ ] Switch stores while offline (multi-store owner) - confirm cached services/customers and the pending queue never mix between stores

`npm run build`, `npx tsc --noEmit`, and `npm run lint` all pass (lint at the pre-existing baseline, no new issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added offline mode for supported stores, including local order queuing and automatic synchronization when connectivity returns.
  - Added offline customer and service lookup using cached data.
  - Added pending-order status, error details, and retry controls in order history.
  - Enabled thermal printing for locally queued orders.
  - Added store settings control for enabling offline mode.

- **Improvements**
  - Points redemption is disabled while offline.
  - Order points are awarded atomically after synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->