### PR TITLE
fix(whatsapp): resolve receipt URL to localhost on Android app

### DIFF
--- a/src/integrations/whatsapp/templates.ts
+++ b/src/integrations/whatsapp/templates.ts
@@ -1,3 +1,4 @@
+import { Capacitor } from '@capacitor/core';
 import { MessageTemplate, OrderCreatedData, OrderCompletedData, OrderReadyForPickupData, PaymentConfirmationData } from './types';
 import { POINTS_TO_CURRENCY_RATE } from '@/components/orders/PayLaterPaymentDialog';
 
@@ -9,13 +10,22 @@ const getReceiptBaseUrl = (): string => {
   if (import.meta.env.VITE_RECEIPT_BASE_URL) {
     return import.meta.env.VITE_RECEIPT_BASE_URL;
   }
-  
-  // In production, use the current domain
-  if (typeof window !== 'undefined') {
+
+  // VITE_APP_ORIGIN is already baked into native builds for the WhatsApp API
+  // base URL (see whatsapp-config.ts) - reuse it here too.
+  if (import.meta.env.VITE_APP_ORIGIN) {
+    return import.meta.env.VITE_APP_ORIGIN;
+  }
+
+  // On native platforms the WebView's own origin is a synthetic local
+  // address (`https://localhost` on Android, `capacitor://localhost` on
+  // iOS), never the real deployed domain, so it must never be used here -
+  // fall straight through to the hardcoded production fallback instead.
+  if (typeof window !== 'undefined' && !Capacitor.isNativePlatform()) {
     return window.location.origin;
   }
-  
-  // Fallback for server-side rendering or build time
+
+  // Fallback for native builds without env vars, SSR, or build time
   return 'https://pos.fahrudina.my.id';
 };
 


### PR DESCRIPTION
## Problem

WhatsApp notification messages sent from the Android app contained receipt links pointing to `https://localhost/receipt/...` instead of the real production domain.

## Root cause

`getReceiptBaseUrl()` in `src/integrations/whatsapp/templates.ts` fell back to `window.location.origin` whenever `VITE_RECEIPT_BASE_URL` was unset. Inside the Capacitor Android WebView, that origin is the synthetic local address `https://localhost` (not the deployed domain), so every generated link was broken.

The Android CI workflows (`build-android.yml` / `release-android.yml`) already set `VITE_APP_ORIGIN=https://pos.fahrudina.my.id` for the WhatsApp API base URL, but `templates.ts` never reused that variable for the receipt link.

## Fix

- `getReceiptBaseUrl()` now falls back to `VITE_APP_ORIGIN` before ever considering `window.location.origin`.
- Added a `Capacitor.isNativePlatform()` guard so `window.location.origin` is never used on native builds at all — it goes straight to the hardcoded `https://pos.fahrudina.my.id` fallback instead of silently emitting a `localhost` link.
- Web deployments are unaffected — `window.location.origin` is still used there as before.

## Verification

- `tsc --noEmit` — no errors
- `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt link generation in the WhatsApp integration.
  * Ensured receipt links use the correct configured or production URL when accessed from native apps.
  * Preserved browser-based URL behavior for web users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->