### PR TITLE
feat(gtm): add resumable email+WhatsApp campaign script for registered accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ research/
 # regenerates this fresh from the web build via `cap add android` on every run.
 android/
 ios/
+
+# GTM campaign run state — contains real recipient emails/phones + send logs
+scripts/gtm-campaign/state.json
+scripts/gtm-campaign/*.log

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "gtm:campaign": "node scripts/gtm-campaign/send-campaign.mjs"
   },
   "dependencies": {
     "@capacitor-community/bluetooth-le": "^7.3.2",

--- a/scripts/gtm-campaign/README.md
+++ b/scripts/gtm-campaign/README.md
@@ -1,0 +1,74 @@
+# GTM campaign sender
+
+One-time go-to-market send to every active registered account in
+`public.users` (laundry owners/staff who signed up for the app) — email
+first, then a WhatsApp follow-up, throttled to **1 WhatsApp message per 15
+minutes** to stay well under WhatsApp's spam/block heuristics for bulk sends.
+
+This does **not** touch `public.customers` (a store's own laundry
+customers) — see the audience note in the script header if you also want to
+run this against that list.
+
+## Before you run this for real
+
+1. **Read and edit `message-copy.mjs`.** It's a first draft — approve or
+   rewrite the subject/body/WhatsApp text before any `--live` run.
+2. **Set the required env vars** (in your shell or a local `.env` — never
+   commit real values):
+
+   | Var | Purpose | Where to get it |
+   |---|---|---|
+   | `SUPABASE_URL` | Same project URL as `src/integrations/supabase/client.ts` | Supabase dashboard → Project Settings → API |
+   | `SUPABASE_SERVICE_ROLE_KEY` | Bypasses RLS to read *all* users across stores | Supabase dashboard → Project Settings → API (⚠️ secret, never expose client-side) |
+   | `RESEND_API_KEY` | Sends the email | resend.com dashboard, after verifying a sending domain |
+   | `GTM_EMAIL_FROM` | Verified "from" address, e.g. `Smart Laundry POS <hello@yourdomain.com>` | Must match the domain verified in Resend |
+   | `WHATSAPP_API_URL`, `WHATSAPP_USERNAME`, `WHATSAPP_PASSWORD` | Same WhatsApp provider already used in production | Same values as the Vercel project's env vars (see `api/whatsapp-send.js`) |
+
+   Any of the email or WhatsApp vars can be left unset — that phase's sends
+   are reported as `skipped-no-provider` per recipient instead of failing,
+   so you can e.g. wire up email now and WhatsApp later.
+
+## Usage
+
+```bash
+# Preview only — no network calls, no state written. Always start here.
+node scripts/gtm-campaign/send-campaign.mjs
+
+# Preview against just the first 3 users
+node scripts/gtm-campaign/send-campaign.mjs --limit=3
+
+# Smoke test against exactly one real recipient before going wide
+node scripts/gtm-campaign/send-campaign.mjs --live --limit=1
+
+# Full live run (asks for typed confirmation first)
+node scripts/gtm-campaign/send-campaign.mjs --live
+
+# Run just one phase (e.g. email already went out, WhatsApp got interrupted)
+node scripts/gtm-campaign/send-campaign.mjs --live --only=whatsapp
+```
+
+## How it behaves
+
+- **Dry run is the default.** Nothing is sent unless you pass `--live`.
+- **`--live` requires typed confirmation** (`SEND <n>`) showing the exact
+  recipient count before anything goes out.
+- **Resumable.** Every send result is written to `state.json` immediately
+  after it happens. If the process dies or you Ctrl+C mid-run (this is
+  expected for the WhatsApp phase — 1 msg/15min means a full run for N
+  recipients takes roughly `(N-1) × 15` minutes), just re-run the same
+  `--live` command: anyone already marked `sent` is skipped.
+- **`state.json` contains real recipient emails/phones and is gitignored.**
+  Don't paste it anywhere public.
+- Because the WhatsApp phase can run for hours, run it under `nohup`,
+  `tmux`, or `screen` rather than in a terminal you might close:
+
+  ```bash
+  nohup node scripts/gtm-campaign/send-campaign.mjs --live > gtm-run.log 2>&1 &
+  ```
+
+## Also available as an npm script
+
+```bash
+npm run gtm:campaign            # dry run
+npm run gtm:campaign -- --live  # live run
+```

--- a/scripts/gtm-campaign/message-copy.mjs
+++ b/scripts/gtm-campaign/message-copy.mjs
@@ -9,7 +9,7 @@
  * Placeholders available: {{name}}, {{email}}
  */
 
-export const emailSubject = '🚀 Kabar Baru dari Smart Laundry POS untuk Usaha Anda';
+export const emailSubject = '🚀 Sekarang Tersedia di Android + Mode Offline — Kabar Baru dari Smart Laundry POS';
 
 export const emailText = `Halo {{name}} 👋
 
@@ -18,6 +18,8 @@ Terima kasih sudah mempercayai Smart Laundry POS untuk membantu mengelola usaha 
 Kami ingin berbagi kabar baik: platform ini terus kami kembangkan supaya makin memudahkan operasional harian Anda — mulai dari pencatatan pesanan dan pembayaran, sampai notifikasi otomatis ke pelanggan lewat WhatsApp.
 
 Beberapa hal yang bisa Anda coba sekarang:
+- 📱 Sekarang tersedia juga sebagai aplikasi Android — install langsung di HP untuk akses lebih cepat
+- 🔌 Mendukung mode offline — tetap bisa catat pesanan walau koneksi internet putus, data otomatis sinkron begitu online kembali
 - Kelola pesanan dan pembayaran dari satu tempat
 - Kirim notifikasi otomatis ke pelanggan (pesanan masuk, selesai, siap diambil)
 - Pantau performa toko lewat dashboard
@@ -35,6 +37,8 @@ export const emailHtml = `<div style="font-family: -apple-system, Segoe UI, Robo
   <p>Kami ingin berbagi kabar baik: platform ini terus kami kembangkan supaya makin memudahkan operasional harian Anda — mulai dari pencatatan pesanan dan pembayaran, sampai notifikasi otomatis ke pelanggan lewat WhatsApp.</p>
   <p><strong>Beberapa hal yang bisa Anda coba sekarang:</strong></p>
   <ul>
+    <li>📱 Sekarang tersedia juga sebagai aplikasi Android — install langsung di HP untuk akses lebih cepat</li>
+    <li>🔌 Mendukung mode offline — tetap bisa catat pesanan walau koneksi internet putus, data otomatis sinkron begitu online kembali</li>
     <li>Kelola pesanan dan pembayaran dari satu tempat</li>
     <li>Kirim notifikasi otomatis ke pelanggan (pesanan masuk, selesai, siap diambil)</li>
     <li>Pantau performa toko lewat dashboard</li>
@@ -47,6 +51,8 @@ export const emailHtml = `<div style="font-family: -apple-system, Segoe UI, Robo
 export const whatsappMessage = `Halo {{name}} 👋
 
 Ini tim Smart Laundry POS. Kami baru saja mengirim email ke {{email}} berisi kabar terbaru seputar platform yang Anda gunakan untuk usaha laundry.
+
+Oh iya, sekarang Smart Laundry POS juga sudah tersedia sebagai aplikasi Android 📱 dan mendukung mode offline 🔌 — tetap bisa dipakai catat pesanan walau internet lagi putus.
 
 Kalau belum sempat cek email, boleh diintip ya — ada info fitur yang mungkin bermanfaat buat operasional toko Anda 🧺✨
 

--- a/scripts/gtm-campaign/message-copy.mjs
+++ b/scripts/gtm-campaign/message-copy.mjs
@@ -1,0 +1,55 @@
+/**
+ * GTM campaign copy — email + WhatsApp.
+ *
+ * ⚠️ DRAFT — REVIEW AND EDIT BEFORE ANY LIVE RUN.
+ * This is a first pass written to match the warm, informal Indonesian tone
+ * already used in src/integrations/whatsapp/templates.ts. Nothing gets sent
+ * until you've read this file and are happy with the wording.
+ *
+ * Placeholders available: {{name}}, {{email}}
+ */
+
+export const emailSubject = '🚀 Kabar Baru dari Smart Laundry POS untuk Usaha Anda';
+
+export const emailText = `Halo {{name}} 👋
+
+Terima kasih sudah mempercayai Smart Laundry POS untuk membantu mengelola usaha laundry Anda.
+
+Kami ingin berbagi kabar baik: platform ini terus kami kembangkan supaya makin memudahkan operasional harian Anda — mulai dari pencatatan pesanan dan pembayaran, sampai notifikasi otomatis ke pelanggan lewat WhatsApp.
+
+Beberapa hal yang bisa Anda coba sekarang:
+- Kelola pesanan dan pembayaran dari satu tempat
+- Kirim notifikasi otomatis ke pelanggan (pesanan masuk, selesai, siap diambil)
+- Pantau performa toko lewat dashboard
+
+Kalau ada masukan, kendala, atau ide fitur yang Anda butuhkan, balas saja email ini — kami senang mendengar dari Anda.
+
+Semoga usahanya makin lancar dan berkah selalu! 🙏😊
+
+Salam hangat,
+Tim Smart Laundry POS`;
+
+export const emailHtml = `<div style="font-family: -apple-system, Segoe UI, Roboto, sans-serif; max-width: 480px; margin: 0 auto; line-height: 1.6; color: #1f2937;">
+  <p>Halo {{name}} 👋</p>
+  <p>Terima kasih sudah mempercayai <strong>Smart Laundry POS</strong> untuk membantu mengelola usaha laundry Anda.</p>
+  <p>Kami ingin berbagi kabar baik: platform ini terus kami kembangkan supaya makin memudahkan operasional harian Anda — mulai dari pencatatan pesanan dan pembayaran, sampai notifikasi otomatis ke pelanggan lewat WhatsApp.</p>
+  <p><strong>Beberapa hal yang bisa Anda coba sekarang:</strong></p>
+  <ul>
+    <li>Kelola pesanan dan pembayaran dari satu tempat</li>
+    <li>Kirim notifikasi otomatis ke pelanggan (pesanan masuk, selesai, siap diambil)</li>
+    <li>Pantau performa toko lewat dashboard</li>
+  </ul>
+  <p>Kalau ada masukan, kendala, atau ide fitur yang Anda butuhkan, balas saja email ini — kami senang mendengar dari Anda.</p>
+  <p>Semoga usahanya makin lancar dan berkah selalu! 🙏😊</p>
+  <p>Salam hangat,<br/>Tim Smart Laundry POS</p>
+</div>`;
+
+export const whatsappMessage = `Halo {{name}} 👋
+
+Ini tim Smart Laundry POS. Kami baru saja mengirim email ke {{email}} berisi kabar terbaru seputar platform yang Anda gunakan untuk usaha laundry.
+
+Kalau belum sempat cek email, boleh diintip ya — ada info fitur yang mungkin bermanfaat buat operasional toko Anda 🧺✨
+
+Semoga usahanya makin lancar dan selalu diberi kesehatan! 🙏😊
+
+_Pesan ini dikirim otomatis dari Smart Laundry POS_`;

--- a/scripts/gtm-campaign/send-campaign.mjs
+++ b/scripts/gtm-campaign/send-campaign.mjs
@@ -1,0 +1,262 @@
+#!/usr/bin/env node
+/**
+ * GTM campaign sender.
+ *
+ * Emails every active registered account in `public.users` first, then
+ * WhatsApp-messages them at a strict 1-message-per-15-minutes cadence to
+ * stay well under WhatsApp's spam/block heuristics for bulk sends.
+ *
+ * SAFE BY DEFAULT: with no flags, this only PREVIEWS what would happen —
+ * recipient count + a rendered sample message — and sends nothing. Pass
+ * --live to actually dispatch, which requires a typed confirmation.
+ *
+ * RESUMABLE: every send result is persisted to state.json immediately, so
+ * killing the process (Ctrl+C, machine restart) and re-running with --live
+ * picks up exactly where it left off instead of re-messaging anyone.
+ *
+ * Usage:
+ *   node scripts/gtm-campaign/send-campaign.mjs                    # dry run, all users
+ *   node scripts/gtm-campaign/send-campaign.mjs --limit=3          # dry run, first 3 only
+ *   node scripts/gtm-campaign/send-campaign.mjs --live --limit=1   # smoke test on 1 real user
+ *   node scripts/gtm-campaign/send-campaign.mjs --live             # full live run
+ *   node scripts/gtm-campaign/send-campaign.mjs --live --only=email
+ *   node scripts/gtm-campaign/send-campaign.mjs --live --only=whatsapp
+ *
+ * See README.md in this directory for required environment variables.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import readline from 'node:readline/promises';
+import { emailSubject, emailHtml, emailText, whatsappMessage } from './message-copy.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const STATE_PATH = path.join(__dirname, 'state.json');
+const WHATSAPP_INTERVAL_MS = 15 * 60 * 1000; // 15 minutes — do not lower without checking with the WA provider
+
+const args = process.argv.slice(2);
+const flag = (name) => args.includes(`--${name}`);
+const opt = (name, fallback) => {
+  const match = args.find((a) => a.startsWith(`--${name}=`));
+  return match ? match.split('=')[1] : fallback;
+};
+
+const LIVE = flag('live');
+const ONLY = opt('only', 'all'); // 'all' | 'email' | 'whatsapp'
+const LIMIT = opt('limit', null);
+
+if (!['all', 'email', 'whatsapp'].includes(ONLY)) {
+  console.error(`Invalid --only=${ONLY}. Expected all | email | whatsapp.`);
+  process.exit(1);
+}
+
+function loadState() {
+  if (!existsSync(STATE_PATH)) return {};
+  return JSON.parse(readFileSync(STATE_PATH, 'utf8'));
+}
+
+function saveState(state) {
+  writeFileSync(STATE_PATH, JSON.stringify(state, null, 2));
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function personalize(template, user) {
+  return template
+    .replace(/\{\{name\}\}/g, user.full_name || 'Bapak/Ibu')
+    .replace(/\{\{email\}\}/g, user.email || '');
+}
+
+// Mirrors WhatsAppClient.formatPhoneNumber (src/integrations/whatsapp/client.ts)
+// so numbers land in the same "62..." shape the provider expects.
+function formatPhone(phone, defaultCountryCode = '62') {
+  const cleaned = String(phone || '').replace(/\D/g, '');
+  if (!cleaned) return null;
+  if (cleaned.startsWith(defaultCountryCode)) return cleaned;
+  if (cleaned.startsWith('0')) return `${defaultCountryCode}${cleaned.slice(1)}`;
+  return `${defaultCountryCode}${cleaned}`;
+}
+
+async function fetchUsers(supabase) {
+  const { data, error } = await supabase
+    .from('users')
+    .select('id, email, phone, full_name, is_active')
+    .eq('is_active', true)
+    .not('email', 'is', null);
+  if (error) throw new Error(`Failed to fetch users: ${error.message}`);
+  return LIMIT ? data.slice(0, Number(LIMIT)) : data;
+}
+
+async function sendEmail(user) {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.GTM_EMAIL_FROM;
+  if (!apiKey || !from) return { status: 'skipped-no-provider' };
+
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from,
+      to: user.email,
+      subject: emailSubject,
+      html: personalize(emailHtml, user),
+      text: personalize(emailText, user),
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Resend HTTP ${res.status}: ${await res.text()}`);
+  }
+  return { status: 'sent' };
+}
+
+// Same endpoint/auth shape as api/whatsapp-send.js, called directly since this
+// script already runs server-side — no need to hop through the Vercel proxy.
+async function sendWhatsApp(user) {
+  const apiUrl = process.env.WHATSAPP_API_URL;
+  const username = process.env.WHATSAPP_USERNAME || 'admin';
+  const password = process.env.WHATSAPP_PASSWORD;
+  const phone = formatPhone(user.phone);
+
+  if (!phone) return { status: 'skipped-no-phone' };
+  if (!apiUrl || !password) return { status: 'skipped-no-provider' };
+
+  const endpoint = apiUrl.endsWith('/api/send-message') ? apiUrl : `${apiUrl}/api/send-message`;
+  const credentials = Buffer.from(`${username}:${password}`).toString('base64');
+  const res = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${credentials}`,
+    },
+    body: JSON.stringify({ to: phone, message: personalize(whatsappMessage, user) }),
+  });
+  if (!res.ok) {
+    throw new Error(`WhatsApp API HTTP ${res.status}: ${await res.text()}`);
+  }
+  return { status: 'sent' };
+}
+
+function printDryRunPreview(users) {
+  const sample = users[0];
+  console.log(`\n=== DRY RUN — nothing will be sent ===`);
+  console.log(`Recipients: ${users.length} active registered account(s)${LIMIT ? ` (--limit=${LIMIT})` : ''}`);
+  console.log(`Phase(s) to run: ${ONLY}`);
+  if (ONLY !== 'email') {
+    const hours = ((users.length - 1) * WHATSAPP_INTERVAL_MS) / 3_600_000;
+    console.log(`Estimated WhatsApp phase duration: ~${hours.toFixed(1)}h for ${users.length} recipients at 1 msg/15min`);
+  }
+  if (sample) {
+    console.log(`\n--- Sample email (to ${sample.email}) ---`);
+    console.log(`Subject: ${emailSubject}`);
+    console.log(personalize(emailText, sample));
+    console.log(`\n--- Sample WhatsApp message (to ${formatPhone(sample.phone)}) ---`);
+    console.log(personalize(whatsappMessage, sample));
+  }
+  console.log(`\nEnv check: RESEND_API_KEY=${process.env.RESEND_API_KEY ? 'set' : 'MISSING'}, GTM_EMAIL_FROM=${process.env.GTM_EMAIL_FROM ? 'set' : 'MISSING'}, WHATSAPP_API_URL=${process.env.WHATSAPP_API_URL ? 'set' : 'MISSING'}, WHATSAPP_PASSWORD=${process.env.WHATSAPP_PASSWORD ? 'set' : 'MISSING'}`);
+  console.log(`\nRun with --live once you've reviewed message-copy.mjs and the env vars above are in place.`);
+}
+
+async function confirmLiveRun(users) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  console.log(`\n⚠️  LIVE RUN: about to message ${users.length} real registered account(s), phase(s): ${ONLY}.`);
+  if (users[0]) console.log(`   Sample recipient: ${users[0].email} / ${users[0].phone}`);
+  const answer = await rl.question(`   Type "SEND ${users.length}" to confirm, anything else to abort: `);
+  rl.close();
+  return answer.trim() === `SEND ${users.length}`;
+}
+
+async function runEmailPhase(users, state) {
+  console.log(`\n📧 Email phase (LIVE)`);
+  for (const user of users) {
+    state[user.id] ??= {};
+    if (state[user.id].email?.status === 'sent') {
+      console.log(`  - ${user.email}: already sent, skipping`);
+      continue;
+    }
+    try {
+      const result = await sendEmail(user);
+      state[user.id].email = { ...result, at: new Date().toISOString() };
+      console.log(`  - ${user.email}: ${result.status}`);
+    } catch (err) {
+      state[user.id].email = { status: 'error', error: err.message, at: new Date().toISOString() };
+      console.error(`  - ${user.email}: ERROR ${err.message}`);
+    }
+    saveState(state);
+  }
+}
+
+async function runWhatsAppPhase(users, state) {
+  console.log(`\n💬 WhatsApp phase (LIVE) — 1 message / 15 min`);
+  for (const [i, user] of users.entries()) {
+    state[user.id] ??= {};
+    if (state[user.id].whatsapp?.status === 'sent') {
+      console.log(`  - ${user.phone}: already sent, skipping`);
+      continue;
+    }
+
+    let status = 'error';
+    try {
+      const result = await sendWhatsApp(user);
+      status = result.status;
+      state[user.id].whatsapp = { ...result, at: new Date().toISOString() };
+      console.log(`  - ${user.phone}: ${result.status}`);
+    } catch (err) {
+      state[user.id].whatsapp = { status: 'error', error: err.message, at: new Date().toISOString() };
+      console.error(`  - ${user.phone}: ERROR ${err.message}`);
+    }
+    saveState(state);
+
+    // Only throttle after an actual send — skip/dry-run/error results don't
+    // count against WhatsApp's rate, so no need to burn 15 minutes on them.
+    const isLast = i === users.length - 1;
+    if (!isLast && status === 'sent') {
+      console.log(`  … waiting 15 minutes before the next WhatsApp send`);
+      await sleep(WHATSAPP_INTERVAL_MS);
+    }
+  }
+}
+
+async function main() {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceKey) {
+    console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY env vars. See README.md.');
+    process.exit(1);
+  }
+
+  const supabase = createClient(supabaseUrl, serviceKey);
+  const users = await fetchUsers(supabase);
+
+  if (users.length === 0) {
+    console.log('No active registered accounts found. Nothing to do.');
+    return;
+  }
+
+  if (!LIVE) {
+    printDryRunPreview(users);
+    return;
+  }
+
+  if (!(await confirmLiveRun(users))) {
+    console.log('Aborted: confirmation did not match.');
+    process.exit(1);
+  }
+
+  const state = loadState();
+  if (ONLY === 'all' || ONLY === 'email') await runEmailPhase(users, state);
+  if (ONLY === 'all' || ONLY === 'whatsapp') await runWhatsAppPhase(users, state);
+
+  console.log('\nDone. See state.json for a full per-recipient log.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## What
Adds `scripts/gtm-campaign/` — a CLI tool for the one-time GTM push: email every active registered account (`public.users`) first, then a WhatsApp follow-up throttled to **1 message per 15 minutes** to stay under WhatsApp's spam/block thresholds.

## Why
No email-sending capability existed anywhere in this codebase, and the existing `/whatsapp-broadcast` page sends 1 msg/second from an open browser tab — neither fits a 15-min-per-message, potentially hours-long, resumable campaign.

## Safety by design
- **Dry-run by default.** No flag = preview only (recipient count + rendered sample message), zero network calls.
- **`--live` requires typed confirmation** of the exact recipient count before dispatching anything.
- **Resumable.** Every send result is persisted to `state.json` (gitignored — contains real emails/phones) immediately, so an interrupted run (expected for a multi-hour WhatsApp phase) can be safely re-run without re-messaging anyone already sent to.
- **Providers are optional per env var** — an unconfigured phase reports `skipped-no-provider` per recipient instead of failing, so email and WhatsApp can be wired up independently.
- **No real send has been made.** This PR only adds the tooling; nothing fires without `SUPABASE_SERVICE_ROLE_KEY` / `RESEND_API_KEY` / `WHATSAPP_*` being explicitly supplied, plus the typed `--live` confirmation.

## Still pending before any real run
- `message-copy.mjs` is a first-draft of the email/WhatsApp copy (Indonesian, matching the tone of `src/integrations/whatsapp/templates.ts`) — needs review/approval.
- Real credentials (Resend API key + verified sending domain, Supabase service role key) need to be supplied out-of-band, never committed.

See `scripts/gtm-campaign/README.md` for full usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)