### PR TITLE
feat(landing): add prominent Android download CTA with Android icon

### DIFF
--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -23,6 +23,20 @@ import './LandingPage.css';
 
 const FONT_LINK_ID = 'tk-landing-fonts';
 
+/** Fixed-name release asset that release-android.yml re-publishes on every
+ * tagged build, so this URL never has to be updated for new versions. */
+const ANDROID_APK_URL =
+  'https://github.com/fahrudina/smart-laundry-pos/releases/latest/download/smart-laundry-pos-latest.apk';
+
+/** lucide-react has no Android glyph, so this is the standard bugdroid head
+ * outline (Material Design Icons, Apache-2.0) — lets the download button
+ * read as "Android app" at a glance instead of the generic Smartphone icon. */
+const AndroidIcon = ({ className }: { className?: string }) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" className={className} aria-hidden="true">
+    <path d="M16.61 15.15C16.15 15.15 15.77 14.78 15.77 14.32S16.15 13.5 16.61 13.5H16.61C17.07 13.5 17.45 13.86 17.45 14.32C17.45 14.78 17.07 15.15 16.61 15.15M7.41 15.15C6.95 15.15 6.57 14.78 6.57 14.32C6.57 13.86 6.95 13.5 7.41 13.5H7.41C7.87 13.5 8.24 13.86 8.24 14.32C8.24 14.78 7.87 15.15 7.41 15.15M16.91 10.14L18.58 7.26C18.67 7.09 18.61 6.88 18.45 6.79C18.28 6.69 18.07 6.75 18 6.92L16.29 9.83C14.95 9.22 13.5 8.9 12 8.91C10.47 8.91 9 9.24 7.73 9.82L6.04 6.91C5.95 6.74 5.74 6.68 5.57 6.78C5.4 6.87 5.35 7.08 5.44 7.25L7.1 10.13C4.25 11.69 2.29 14.58 2 18H22C21.72 14.59 19.77 11.7 16.91 10.14H16.91Z" />
+  </svg>
+);
+
 /** Loads the ticket-stub type pair only while the landing page is mounted,
  * so authenticated app sessions never pay for this download. */
 const useLandingFonts = () => {
@@ -248,6 +262,13 @@ export const LandingPage: React.FC = () => {
                 <Download className="h-4 w-4" />
                 Install Manual
               </button>
+              <a
+                href={ANDROID_APK_URL}
+                className="hidden sm:inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-sm border border-[var(--tk-line)] text-[var(--tk-ink-soft)] hover:bg-[var(--tk-paper-soft)] transition-colors"
+              >
+                <AndroidIcon className="h-4 w-4" />
+                Download Android
+              </a>
               <button
                 onClick={() => navigate('/login')}
                 className="inline-flex items-center px-4 sm:px-5 py-2 text-sm sm:text-base font-semibold rounded-sm bg-[var(--tk-ink)] text-[var(--tk-paper)] hover:bg-[var(--tk-graphite)] transition-colors"
@@ -727,10 +748,10 @@ export const LandingPage: React.FC = () => {
                   Install Guide
                 </button>
                 <a
-                  href="https://github.com/fahrudina/smart-laundry-pos/releases/latest/download/smart-laundry-pos-latest.apk"
+                  href={ANDROID_APK_URL}
                   className="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-medium border border-white/25 rounded-sm hover:bg-white/10 transition-colors"
                 >
-                  <Smartphone className="h-4 w-4" />
+                  <AndroidIcon className="h-4 w-4" />
                   Download APK Android
                 </a>
               </div>


### PR DESCRIPTION
## What
- Adds a **"Download Android"** link to the sticky header on the landing page (`pos.fahrudina.my.id`), next to "Install Manual" / "Masuk" — visible on first load, not just buried in the footer.
- Both the new header link and the existing footer "Download APK Android" button now use a proper Android glyph (`AndroidIcon`, inline Material Design Icons "android" SVG path, Apache-2.0) instead of the generic lucide-react `Smartphone` icon.

## Why
The APK download button already existed, but only in the footer, easy to miss above the fold. This surfaces it earlier and makes the button visually read as "Android app" at a glance.

## Link target
Both buttons point at the same existing asset URL, unchanged:
`https://github.com/fahrudina/smart-laundry-pos/releases/latest/download/smart-laundry-pos-latest.apk`
— the fixed-name alias that `release-android.yml` republishes on every tagged release, so no maintenance needed as new versions ship.

## Verification
- `npx tsc --noEmit` — no errors
- `npm run build` — succeeds, prerender step included

🤖 Generated with [Claude Code](https://claude.com/claude-code)